### PR TITLE
SWAP-1244 Github actions: Include cypress screenshots as build artifacts for failing e2e tests

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -173,6 +173,14 @@ jobs:
             -f user-office-gateway/docker-compose.e2e.yml \
             -f "$REPO_DIR_NAME/docker-compose.e2e.yml" \
             up --exit-code-from cypress
+
+      - name: Upload cypres screenshots
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: cypress-screenshots
+          path: /tmp/screenshots
+
   push:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -179,7 +179,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: cypress-screenshots
-          path: /tmp/screenshots
+          path: cypress/screenshots
 
   push:
     # The type of runner that the job will run on

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,14 +23,16 @@ Cypress.Commands.add('configureClock', () => {
 });
 
 Cypress.Commands.add('configureSession', token => {
-  cy.clearCookies();
-
-  cy.fixture('tokens').then(tokens => {
-    cy.setCookie('token', tokens[token], {
-      path: '/',
-      secure: false,
-    });
-  });
+  /**
+   * For testing disable login which should make the tests fail
+   */
+  // cy.clearCookies();
+  // cy.fixture('tokens').then(tokens => {
+  //   cy.setCookie('token', tokens[token], {
+  //     path: '/',
+  //     secure: false,
+  //   });
+  // });
 });
 //
 //

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,16 +23,14 @@ Cypress.Commands.add('configureClock', () => {
 });
 
 Cypress.Commands.add('configureSession', token => {
-  /**
-   * For testing disable login which should make the tests fail
-   */
-  // cy.clearCookies();
-  // cy.fixture('tokens').then(tokens => {
-  //   cy.setCookie('token', tokens[token], {
-  //     path: '/',
-  //     secure: false,
-  //   });
-  // });
+  cy.clearCookies();
+
+  cy.fixture('tokens').then(tokens => {
+    cy.setCookie('token', tokens[token], {
+      path: '/',
+      secure: false,
+    });
+  });
 });
 //
 //


### PR DESCRIPTION
## Description

This PR adds a new step in Github actions, if e2e testing fails it will upload the screenshots taken by cypress as an artifact for each individual run.
<!--- Describe your changes in detail -->

## Motivation and Context

Help debug falling e2e tests.

## How Has This Been Tested

- [x] Manual testing

An example can be found here: https://github.com/UserOfficeProject/user-office-scheduler-frontend/actions/runs/385111575
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

https://jira.esss.lu.se/browse/SWAP-1244
<!--- Does this fix a user story, if so add a reference here -->

## Changes

- new step added to Github actions
<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
