### PR TITLE
SWAP-1495 & SWAP-1493: Cleanup schedule steps, make the tabs clickable

### DIFF
--- a/cypress/integration/proposal-booking.spec.ts
+++ b/cypress/integration/proposal-booking.spec.ts
@@ -335,10 +335,7 @@ context('Proposal booking tests ', () => {
     describe('Review step', () => {
       it('should request confirmation to activate proposal booking', () => {
         cy.get('[data-cy=btn-next]').click();
-        cy.get('[data-cy=btn-next]').click();
-        cy.get('[data-cy=btn-next]').click();
 
-        cy.contains(/warning/i);
         cy.contains(/activate booking/i).as('activateBookingBtn');
 
         cy.get('@activateBookingBtn').should('be.disabled');
@@ -395,10 +392,7 @@ context('Proposal booking tests ', () => {
 
       it('should be able to go through the process again after restarting', () => {
         cy.get('[data-cy=btn-next]').click();
-        cy.get('[data-cy=btn-next]').click();
-        cy.get('[data-cy=btn-next]').click();
 
-        cy.contains(/warning/i);
         cy.contains(/activate booking/i).as('activateBookingBtn');
 
         cy.get('@activateBookingBtn').should('be.disabled');

--- a/cypress/integration/proposal-booking.spec.ts
+++ b/cypress/integration/proposal-booking.spec.ts
@@ -190,6 +190,11 @@ context('Proposal booking tests ', () => {
         cy.contains(/time slots with equipments/i);
       });
 
+      it('should be able to navigate using tabs', () => {
+        cy.get('[data-cy="booking-step-BOOK_EVENTS"]').click();
+        cy.contains('Save draft');
+      });
+
       it('should be able to assign available equipments to time slot', () => {
         cy.contains(/no records to show/i);
 
@@ -353,6 +358,15 @@ context('Proposal booking tests ', () => {
     });
 
     describe('Final step', () => {
+      it('should be able to navigate using tabs', () => {
+        cy.get('[data-cy="booking-step-BOOK_EVENTS"]').click();
+        cy.contains(/save draft/i);
+        cy.get('[data-cy="booking-step-BOOK_EQUIPMENT"]').click();
+        cy.contains(/time slots with equipments/i);
+        cy.get('[data-cy="booking-step-FINALIZE"]').click();
+        cy.contains(/save lost time/i);
+      });
+
       it('should be able to log lost time', () => {
         cy.get('[data-cy=btn-add-lost-time]').click();
 

--- a/src/components/common/SplitButton.tsx
+++ b/src/components/common/SplitButton.tsx
@@ -20,6 +20,7 @@ type SplitButtonProps<T> = {
   options: SplitButtonOption<T>[];
   label: string;
   disabled?: boolean;
+  dropdownDisabled?: boolean;
   onClick?: (selectedKey: T) => void;
 };
 
@@ -27,6 +28,7 @@ export default function SplitButton<T extends string>({
   options,
   label,
   disabled,
+  dropdownDisabled,
   onClick,
 }: SplitButtonProps<T>) {
   const [open, setOpen] = useState(false);
@@ -78,6 +80,7 @@ export default function SplitButton<T extends string>({
           aria-label={label}
           aria-haspopup="menu"
           onClick={handleToggle}
+          disabled={dropdownDisabled}
         >
           <ArrowDropDownIcon />
         </Button>

--- a/src/components/proposalBooking/ProposalBookingDialog.tsx
+++ b/src/components/proposalBooking/ProposalBookingDialog.tsx
@@ -32,7 +32,7 @@ const useStyles = makeStyles(() => ({
 
 export enum ProposalBookingSteps {
   BOOK_EVENTS = 0,
-  EQUIPMENT_BOOKING,
+  BOOK_EQUIPMENT,
   // REQUEST_REVIEW,
   // REVIEW_FEEDBACKS,
   FINALIZE,
@@ -45,7 +45,7 @@ const ProposalBookingStepNameMap: Record<
   string
 > = {
   BOOK_EVENTS: 'Book events',
-  EQUIPMENT_BOOKING: 'Equipment booking',
+  BOOK_EQUIPMENT: 'Equipment booking',
   // REQUEST_REVIEW: 'Request review',
   // REVIEW_FEEDBACKS: 'Review feedbacks',
   FINALIZE: 'Finalize',
@@ -54,7 +54,7 @@ const ProposalBookingStepNameMap: Record<
 
 const steps = [
   ProposalBookingStepNameMap.BOOK_EVENTS,
-  ProposalBookingStepNameMap.EQUIPMENT_BOOKING,
+  ProposalBookingStepNameMap.BOOK_EQUIPMENT,
   ProposalBookingStepNameMap.FINALIZE,
   ProposalBookingStepNameMap.CLOSED,
 ];
@@ -76,7 +76,7 @@ function getActiveStep(props: ProposalBookingDialogStepProps) {
   switch (props.activeStep) {
     case ProposalBookingSteps.BOOK_EVENTS:
       return <BookingEventStep {...props} />;
-    case ProposalBookingSteps.EQUIPMENT_BOOKING:
+    case ProposalBookingSteps.BOOK_EQUIPMENT:
       return <EquipmentBookingStep {...props} />;
     // case ProposalBookingSteps.REQUEST_REVIEW:
     //   return (
@@ -222,6 +222,7 @@ export default function ProposalBookingDialog({
         {steps.map((label, index) => (
           <Step key={label}>
             <StepButton
+              data-cy={`booking-step-${ProposalBookingSteps[index]}`}
               onClick={handleSetStep(index)}
               completed={
                 index <=

--- a/src/components/proposalBooking/ProposalBookingDialog.tsx
+++ b/src/components/proposalBooking/ProposalBookingDialog.tsx
@@ -6,8 +6,8 @@ import {
   DialogTitle,
   makeStyles,
   Step,
-  StepLabel,
   Stepper,
+  StepButton,
 } from '@material-ui/core';
 import React, { useContext, useEffect, useState } from 'react';
 
@@ -21,8 +21,8 @@ import BookingEventStep from './bookingSteps/BookingEventStep';
 import ClosedStep from './bookingSteps/ClosedStep';
 import EquipmentBookingStep from './bookingSteps/EquipmentBookingStep';
 import FinalizeStep from './bookingSteps/FinalizeStep';
-import RequestReviewStep from './bookingSteps/RequestReviewStep';
-import ReviewFeedbackStep from './bookingSteps/ReviewFeedbackStep';
+// import RequestReviewStep from './bookingSteps/RequestReviewStep';
+// import ReviewFeedbackStep from './bookingSteps/ReviewFeedbackStep';
 
 const useStyles = makeStyles(() => ({
   fullHeight: {
@@ -30,103 +30,87 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
+export enum ProposalBookingSteps {
+  BOOK_EVENTS = 0,
+  EQUIPMENT_BOOKING,
+  // REQUEST_REVIEW,
+  // REVIEW_FEEDBACKS,
+  FINALIZE,
+
+  CLOSED,
+}
+
+const ProposalBookingStepNameMap: Record<
+  keyof typeof ProposalBookingSteps,
+  string
+> = {
+  BOOK_EVENTS: 'Book events',
+  EQUIPMENT_BOOKING: 'Equipment booking',
+  // REQUEST_REVIEW: 'Request review',
+  // REVIEW_FEEDBACKS: 'Review feedbacks',
+  FINALIZE: 'Finalize',
+  CLOSED: 'Closed',
+};
+
 const steps = [
-  /* 0*/ 'Book events',
-  /* 1*/ 'Equipment booking',
-  /* 2*/ 'Request review',
-  /* 3*/ 'Review feedbacks',
-  /* 4*/ 'Finalize',
-  /* 5 - Closed (not visible as a step) */
+  ProposalBookingStepNameMap.BOOK_EVENTS,
+  ProposalBookingStepNameMap.EQUIPMENT_BOOKING,
+  ProposalBookingStepNameMap.FINALIZE,
+  ProposalBookingStepNameMap.CLOSED,
 ];
 const maxSteps = steps.length;
 
-function getActiveStep({
-  activeStep,
-  isDirty,
-  proposalBooking,
-  handleNext,
-  handleBack,
-  handleResetSteps,
-  handleSetDirty,
-}: {
+export type ProposalBookingDialogStepProps = {
   activeStep: number;
+  activeStatus: ProposalBookingStatus | null;
   proposalBooking: InstrumentProposalBooking;
   isDirty: boolean;
   handleNext: () => void;
   handleBack: () => void;
   handleResetSteps: () => void;
   handleSetDirty: (isDirty: boolean) => void;
-}) {
-  switch (activeStep) {
-    case 0:
-      return (
-        <BookingEventStep
-          {...{
-            proposalBooking,
-            isDirty,
-            handleSetDirty,
-            handleNext,
-          }}
-        />
-      );
-    case 1:
-      return (
-        <EquipmentBookingStep
-          {...{
-            proposalBooking,
-            isDirty,
-            handleSetDirty,
-            handleNext,
-            handleBack,
-          }}
-        />
-      );
-    case 2:
-      return (
-        <RequestReviewStep
-          {...{
-            proposalBooking,
-            handleBack,
-            handleNext,
-          }}
-        />
-      );
-    case 3:
-      return (
-        <ReviewFeedbackStep
-          {...{
-            proposalBooking,
-            handleBack,
-            handleNext,
-          }}
-        />
-      );
-    case 4:
-      return (
-        <FinalizeStep
-          {...{
-            proposalBooking,
-            handleSetDirty,
-            isDirty,
-            handleNext,
-            handleResetSteps,
-          }}
-        />
-      );
+  handleSetActiveStepByStatus: (status: ProposalBookingStatus) => void;
+};
+
+function getActiveStep(props: ProposalBookingDialogStepProps) {
+  switch (props.activeStep) {
+    case ProposalBookingSteps.BOOK_EVENTS:
+      return <BookingEventStep {...props} />;
+    case ProposalBookingSteps.EQUIPMENT_BOOKING:
+      return <EquipmentBookingStep {...props} />;
+    // case ProposalBookingSteps.REQUEST_REVIEW:
+    //   return (
+    //     <RequestReviewStep
+    //       {...props}
+    //     />
+    //   );
+    // case ProposalBookingSteps.REVIEW_FEEDBACKS:
+    //   return (
+    //     <ReviewFeedbackStep
+    //       {...props}
+    //     />
+    //   );
+    case ProposalBookingSteps.FINALIZE:
+      return <FinalizeStep {...props} />;
+
+    case ProposalBookingSteps.CLOSED:
+      return <ClosedStep {...props} />;
 
     default:
       return <DialogContent>Unknown step</DialogContent>;
   }
 }
 
-const getActiveStepByStatus = (status: ProposalBookingStatus): number => {
+const getActiveStepByStatus = (
+  status: ProposalBookingStatus | null
+): number => {
   switch (status) {
     case ProposalBookingStatus.DRAFT:
-      return 0;
+      return ProposalBookingSteps.BOOK_EVENTS;
     case ProposalBookingStatus.BOOKED:
-      return 4;
+      return ProposalBookingSteps.FINALIZE;
     case ProposalBookingStatus.CLOSED:
-      return 5;
+      return ProposalBookingSteps.CLOSED;
 
     default:
       return -1;
@@ -148,6 +132,10 @@ export default function ProposalBookingDialog({
 
   const { showConfirmation } = useContext(AppContext);
   const [activeStep, setActiveStep] = useState(-1);
+  const [
+    activeStatus,
+    setActiveStatus,
+  ] = useState<ProposalBookingStatus | null>(null);
   const [isDirty, setIsDirty] = useState(false);
 
   const { loading, proposalBooking } = useProposalBooking(
@@ -157,11 +145,12 @@ export default function ProposalBookingDialog({
   useEffect(() => {
     if (!loading && proposalBooking) {
       setActiveStep(getActiveStepByStatus(proposalBooking.status));
+      setActiveStatus(proposalBooking.status);
     }
   }, [loading, proposalBooking]);
 
   const handleResetSteps = () => {
-    setActiveStep(0);
+    setActiveStep(ProposalBookingSteps.BOOK_EVENTS);
     setIsDirty(false);
   };
 
@@ -173,6 +162,15 @@ export default function ProposalBookingDialog({
   const handleBack = () => {
     setActiveStep(prevStep => Math.max(prevStep - 1, 0));
     setIsDirty(false);
+  };
+
+  const handleSetStep = (step: number) => () => {
+    setActiveStep(step);
+    setIsDirty(false);
+  };
+
+  const handleSetActiveStepByStatus = (status: ProposalBookingStatus) => {
+    setActiveStatus(status);
   };
 
   const handleCloseDialog = () => {
@@ -220,27 +218,34 @@ export default function ProposalBookingDialog({
       }}
     >
       <DialogTitle>Proposal booking</DialogTitle>
-      <Stepper activeStep={activeStep}>
-        {steps.map(label => (
+      <Stepper nonLinear activeStep={activeStep}>
+        {steps.map((label, index) => (
           <Step key={label}>
-            <StepLabel>{label}</StepLabel>
+            <StepButton
+              onClick={handleSetStep(index)}
+              completed={
+                index <=
+                Math.max(getActiveStepByStatus(activeStatus), activeStep)
+              }
+              disabled={index > getActiveStepByStatus(activeStatus)}
+            >
+              {label}
+            </StepButton>
           </Step>
         ))}
       </Stepper>
       {proposalBooking &&
-        (activeStep === steps.length ? (
-          <ClosedStep proposalBooking={proposalBooking} />
-        ) : (
-          getActiveStep({
-            activeStep,
-            proposalBooking,
-            isDirty,
-            handleNext,
-            handleBack,
-            handleSetDirty,
-            handleResetSteps,
-          })
-        ))}
+        getActiveStep({
+          activeStep,
+          activeStatus,
+          proposalBooking,
+          isDirty,
+          handleNext,
+          handleBack,
+          handleSetDirty,
+          handleResetSteps,
+          handleSetActiveStepByStatus,
+        })}
       <DialogActions>
         <Button
           color="primary"

--- a/src/components/proposalBooking/bookingSteps/BookingEventStep.tsx
+++ b/src/components/proposalBooking/bookingSteps/BookingEventStep.tsx
@@ -28,12 +28,13 @@ import React, { useContext, useEffect, useMemo, useState } from 'react';
 
 import Loader from 'components/common/Loader';
 import { AppContext } from 'context/AppContext';
+import { ProposalBookingStatus } from 'generated/sdk';
 import { useDataApi } from 'hooks/common/useDataApi';
-import { DetailedProposalBooking } from 'hooks/proposalBooking/useProposalBooking';
 import useProposalBookingScheduledEvents from 'hooks/scheduledEvent/useProposalBookingScheduledEvents';
 import { parseTzLessDateTime, toTzLessDateTime } from 'utils/date';
 import { hasOverlappingEvents } from 'utils/scheduledEvent';
 
+import { ProposalBookingDialogStepProps } from '../ProposalBookingDialog';
 import TimeTable, { TimeTableRow } from '../TimeTable';
 
 const useStyles = makeStyles(theme => ({
@@ -72,19 +73,15 @@ const formatDuration = (durSec: number) =>
     largest: 3,
   });
 
-type BookingEventStepProps = {
-  proposalBooking: DetailedProposalBooking;
-  isDirty: boolean;
-  handleNext: () => void;
-  handleSetDirty: (isDirty: boolean) => void;
-};
-
 export default function BookingEventStep({
+  activeStatus,
   proposalBooking,
   isDirty,
   handleNext,
   handleSetDirty,
-}: BookingEventStepProps) {
+}: ProposalBookingDialogStepProps) {
+  const isStepReadOnly = activeStatus !== ProposalBookingStatus.DRAFT;
+
   const {
     call: { startCycle, endCycle, cycleComment },
     proposal: { title },
@@ -317,8 +314,8 @@ export default function BookingEventStep({
 
       <DialogContent>
         <TimeTable
-          selectable
-          editable
+          selectable={!isStepReadOnly}
+          editable={!isStepReadOnly}
           maxHeight={380}
           rows={rows}
           handleRowsChange={handleRowsChange}
@@ -332,6 +329,7 @@ export default function BookingEventStep({
                 className={classes.spacingLeft}
                 onClick={handleAdd}
                 data-cy="btn-add-time-slot"
+                disabled={isStepReadOnly}
               >
                 Add
               </Button>
@@ -347,6 +345,7 @@ export default function BookingEventStep({
           startIcon={<SaveIcon />}
           onClick={handleSaveDraft}
           data-cy="btn-save"
+          disabled={isStepReadOnly}
         >
           Save draft
         </Button>
@@ -355,6 +354,7 @@ export default function BookingEventStep({
           color="primary"
           onClick={handleSaveAndContinue}
           data-cy="btn-next"
+          disabled={isStepReadOnly}
         >
           Save and continue
         </Button>

--- a/src/components/proposalBooking/bookingSteps/ClosedStep.tsx
+++ b/src/components/proposalBooking/bookingSteps/ClosedStep.tsx
@@ -4,9 +4,9 @@ import React, { useEffect, useState } from 'react';
 
 import Loader from 'components/common/Loader';
 import useProposalBookingLostTimes from 'hooks/lostTime/useProposalBookingLostTimes';
-import { DetailedProposalBooking } from 'hooks/proposalBooking/useProposalBooking';
 import { parseTzLessDateTime } from 'utils/date';
 
+import { ProposalBookingDialogStepProps } from '../ProposalBookingDialog';
 import TimeTable, { TimeTableRow } from '../TimeTable';
 
 const useStyles = makeStyles(() => ({
@@ -16,11 +16,9 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-type ClosedStepStepProps = {
-  proposalBooking: DetailedProposalBooking;
-};
-
-export default function ClosedStep({ proposalBooking }: ClosedStepStepProps) {
+export default function ClosedStep({
+  proposalBooking,
+}: ProposalBookingDialogStepProps) {
   const classes = useStyles();
 
   const { loading, lostTimes } = useProposalBookingLostTimes(

--- a/src/components/proposalBooking/bookingSteps/RequestReviewStep.tsx
+++ b/src/components/proposalBooking/bookingSteps/RequestReviewStep.tsx
@@ -6,18 +6,12 @@ import {
 } from '@material-ui/core';
 import React from 'react';
 
-import { DetailedProposalBooking } from 'hooks/proposalBooking/useProposalBooking';
-
-type RequestReviewStepProps = {
-  proposalBooking: DetailedProposalBooking;
-  handleBack: () => void;
-  handleNext: () => void;
-};
+import { ProposalBookingDialogStepProps } from '../ProposalBookingDialog';
 
 export default function RequestReviewStep({
   handleBack,
   handleNext,
-}: RequestReviewStepProps) {
+}: ProposalBookingDialogStepProps) {
   return (
     <>
       <DialogContent>

--- a/src/components/proposalBooking/bookingSteps/ReviewFeedbackStep.tsx
+++ b/src/components/proposalBooking/bookingSteps/ReviewFeedbackStep.tsx
@@ -15,7 +15,8 @@ import React, { useState } from 'react';
 
 import Loader from 'components/common/Loader';
 import { useDataApi } from 'hooks/common/useDataApi';
-import { DetailedProposalBooking } from 'hooks/proposalBooking/useProposalBooking';
+
+import { ProposalBookingDialogStepProps } from '../ProposalBookingDialog';
 
 const useStyles = makeStyles(theme => ({
   root: { display: 'flex', flexDirection: 'column' },
@@ -32,17 +33,11 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-type ReviewFeedbackStepProps = {
-  proposalBooking: DetailedProposalBooking;
-  handleBack: () => void;
-  handleNext: () => void;
-};
-
 export default function ReviewFeedbackStep({
   proposalBooking,
   handleBack,
   handleNext,
-}: ReviewFeedbackStepProps) {
+}: ProposalBookingDialogStepProps) {
   const classes = useStyles();
   const { enqueueSnackbar } = useSnackbar();
   const api = useDataApi();

--- a/src/components/proposalBooking/bookingSteps/equipmentBooking/TimeSlotEquipmentTable.tsx
+++ b/src/components/proposalBooking/bookingSteps/equipmentBooking/TimeSlotEquipmentTable.tsx
@@ -34,9 +34,11 @@ const useRowStyles = makeStyles({
 
 function Row({
   row,
+  readOnly,
   onDeleteAssignment,
 }: {
   row: ScheduledEventWithEquipments;
+  readOnly?: boolean;
   onDeleteAssignment: (equipmentId: string, scheduledEventId: string) => void;
 }) {
   const [open, setOpen] = useState(false);
@@ -84,6 +86,7 @@ function Row({
                         <IconButton
                           size="small"
                           data-cy="btn-delete-assignment"
+                          disabled={readOnly}
                           onClick={() =>
                             onDeleteAssignment(equipment.id, row.id)
                           }
@@ -114,9 +117,11 @@ function Row({
 
 export default function TimeSlotEquipmentTable({
   rows,
+  readOnly,
   onDeleteAssignment,
 }: {
   rows: ScheduledEventWithEquipments[];
+  readOnly?: boolean;
   onDeleteAssignment: (equipmentId: string, scheduledEventId: string) => void;
 }) {
   return (
@@ -134,6 +139,7 @@ export default function TimeSlotEquipmentTable({
             <Row
               key={row.id}
               row={row}
+              readOnly={readOnly}
               onDeleteAssignment={onDeleteAssignment}
             />
           ))}


### PR DESCRIPTION
## Description

This PR cleans up the steps in proposal booking and makes the steps clickable, letting the user navigate between steps (if the previous steps were already completed).
<!--- Describe your changes in detail -->

## Motivation and Context

Remove unused and meaningless parts, make navigation more user-friendly.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

- [x] e2e tests
- [x] manual testing 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

https://jira.esss.lu.se/browse/SWAP-1495
https://jira.esss.lu.se/browse/SWAP-1493
<!--- Does this fix a user story, if so add a reference here -->

## Changes

- allow navigation between steps
- unimplemented steps removed
- small refactoring/cleanup
<!--- What types of changes does your code introduce? In what place? -->

## Depends on

https://github.com/UserOfficeProject/user-office-scheduler-backend/pull/26
<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
