### PR TITLE
add opacity to the draft event

### DIFF
--- a/cypress/integration/proposal-booking.spec.ts
+++ b/cypress/integration/proposal-booking.spec.ts
@@ -102,6 +102,16 @@ context('Proposal booking tests ', () => {
         cy.contains(/time slots with equipments/i);
       });
 
+      it('Draft events should have opacity', () => {
+        cy.get('[data-cy="btn-close-dialog"]').click();
+
+        cy.get('[title="14:00 – 15:00: User operations"]').should(
+          'have.css',
+          'opacity',
+          '0.6'
+        );
+      });
+
       it('should be able to edit time slot', () => {
         cy.get('[data-cy=btn-time-table-edit-row]').click();
 
@@ -280,9 +290,7 @@ context('Proposal booking tests ', () => {
 
         cy.get('[data-cy="add-equipment-responsible"]').click();
 
-        cy.get('input[type="checkbox"]')
-          .first()
-          .click();
+        cy.get('input[type="checkbox"]').first().click();
 
         cy.get('[data-cy="assign-selected-users"]').click();
 
@@ -300,9 +308,7 @@ context('Proposal booking tests ', () => {
 
         cy.get('[data-cy="add-equipment-responsible"]').click();
 
-        cy.get('input[type="checkbox"]')
-          .first()
-          .click();
+        cy.get('input[type="checkbox"]').first().click();
 
         cy.get('[data-cy="assign-selected-users"]').click();
 
@@ -585,6 +591,16 @@ context('Proposal booking tests ', () => {
         cy.wait(500);
 
         cy.contains(/Proposal booking is already closed, you can not edit it/i);
+      });
+
+      it('Closed events should have gray color and opacity', () => {
+        cy.get('[data-cy="btn-close-dialog"]').click();
+
+        cy.get('[title="14:00 – 15:00: User operations"]').should(
+          'have.css',
+          'background-color',
+          'rgba(0, 0, 0, 0.5)'
+        );
       });
     });
   });

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -23,6 +23,7 @@ import {
   GetScheduledEventsQuery,
   Call,
   Proposal,
+  ProposalBooking,
 } from 'generated/sdk';
 import { useQuery } from 'hooks/common/useQuery';
 import useInstrumentProposalBookings, {
@@ -170,7 +171,7 @@ export default function Calendar() {
           ...event,
           bookingType: ScheduledEventBookingType.EQUIPMENT,
           description: eq.name,
-          proposalBooking: event.proposalBooking,
+          proposalBooking: event.proposalBooking as ProposalBooking,
           instrument: event.instrument,
           scheduledBy: event.scheduledBy,
         }))

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -53,10 +53,10 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-function transformEvent(
+const transformEvent = (
   scheduledEvents: GetScheduledEventsQuery['scheduledEvents']
-): CalendarScheduledEvent[] {
-  return scheduledEvents.map((scheduledEvent) => ({
+): CalendarScheduledEvent[] =>
+  scheduledEvents.map((scheduledEvent) => ({
     id: scheduledEvent.id,
     start: parseTzLessDateTime(scheduledEvent.startsAt).toDate(),
     end: parseTzLessDateTime(scheduledEvent.endsAt).toDate(),
@@ -67,7 +67,6 @@ function transformEvent(
     instrument: scheduledEvent.instrument,
     scheduledBy: scheduledEvent.scheduledBy,
   }));
-}
 
 function isOverlapping(
   { start, end }: { start: Date | string; end: Date | string },
@@ -159,18 +158,16 @@ export default function Calendar() {
 
   const eqEventsTransformed: GetScheduledEventsQuery['scheduledEvents'] =
     eqEvents
-      .map((eq) => {
-        return eq.events.map((event) => {
-          return {
-            ...event,
-            bookingType: ScheduledEventBookingType.EQUIPMENT,
-            description: eq.name,
-            proposalBooking: null,
-            instrument: event.instrument,
-            scheduledBy: event.scheduledBy,
-          };
-        });
-      })
+      .map((eq) =>
+        eq.events.map((event) => ({
+          ...event,
+          bookingType: ScheduledEventBookingType.EQUIPMENT,
+          description: eq.name,
+          proposalBooking: event.proposalBooking,
+          instrument: event.instrument,
+          scheduledBy: event.scheduledBy,
+        }))
+      )
       .flat(1);
 
   const events = useMemo(

--- a/src/components/calendar/Event.tsx
+++ b/src/components/calendar/Event.tsx
@@ -37,6 +37,10 @@ export const isDraftEvent = (
   proposalBooking?: Pick<ProposalBooking, 'status'> | null
 ) => proposalBooking?.status === ProposalBookingStatus.DRAFT;
 
+export const isClosedEvent = (
+  proposalBooking?: Pick<ProposalBooking, 'status'> | null
+) => proposalBooking?.status === ProposalBookingStatus.CLOSED;
+
 function getBookingTypeStyle(
   bookingType: ScheduledEventBookingType
 ): CSSProperties | undefined {
@@ -71,16 +75,25 @@ function getBookingTypeStyle(
   }
 }
 
+const getClosedBookingStyle = (): CSSProperties => ({
+  backgroundColor: 'rgba(0, 0, 0, 0.5)',
+  color: '#fff',
+});
+
 export function eventPropGetter(event: CalendarScheduledEvent): {
   className?: string;
   style?: CSSProperties;
 } {
+  const eventStyle = isClosedEvent(event.proposalBooking)
+    ? getClosedBookingStyle()
+    : getBookingTypeStyle(event.bookingType);
+
   return {
     style: {
       borderRadius: 0,
       border: '1px solid #FFF',
-      ...getBookingTypeStyle(event.bookingType),
       opacity: isDraftEvent(event.proposalBooking) ? '0.6' : 'unset',
+      ...eventStyle,
     },
   };
 }

--- a/src/components/calendar/Event.tsx
+++ b/src/components/calendar/Event.tsx
@@ -6,6 +6,8 @@ import EquipmentBookingInfo from 'components/equipment/EquipmentBookingInfo';
 import ProposalBookingInfo from 'components/proposalBooking/ProposalBookingInfo';
 import {
   GetScheduledEventsQuery,
+  ProposalBooking,
+  ProposalBookingStatus,
   ScheduledEvent,
   ScheduledEventBookingType,
 } from 'generated/sdk';
@@ -30,6 +32,10 @@ const useStyles = makeStyles(() => ({
     marginTop: 5,
   },
 }));
+
+export const isDraftEvent = (
+  proposalBooking?: Pick<ProposalBooking, 'status'> | null
+) => proposalBooking?.status === ProposalBookingStatus.DRAFT;
 
 function getBookingTypeStyle(
   bookingType: ScheduledEventBookingType
@@ -74,6 +80,7 @@ export function eventPropGetter(event: CalendarScheduledEvent): {
       borderRadius: 0,
       border: '1px solid #FFF',
       ...getBookingTypeStyle(event.bookingType),
+      opacity: isDraftEvent(event.proposalBooking) ? '0.6' : 'unset',
     },
   };
 }
@@ -101,6 +108,7 @@ export default function Event({
           scheduledBy={
             `${scheduledBy?.firstname} ${scheduledBy?.lastname}` ?? 'NA'
           }
+          proposalBooking={proposalBooking}
         />
       );
     default:

--- a/src/components/equipment/EquipmentBookingInfo.tsx
+++ b/src/components/equipment/EquipmentBookingInfo.tsx
@@ -1,7 +1,7 @@
 import { makeStyles } from '@material-ui/core';
 import React from 'react';
 
-import { isDraftEvent } from 'components/calendar/Event';
+import { isClosedEvent, isDraftEvent } from 'components/calendar/Event';
 import { ProposalBooking } from 'generated/sdk';
 
 const useStyles = makeStyles(() => ({
@@ -36,7 +36,8 @@ function EquipmentBookingInfo({
   return (
     <div className={classes.container}>
       <strong>
-        {isDraftEvent(proposalBooking) ? '[DRAFT] - ' : ''}
+        {isDraftEvent(proposalBooking) ? '[Draft] - ' : ''}
+        {isClosedEvent(proposalBooking) ? '[Closed] - ' : ''}
         {name}
       </strong>
       <div className={classes.title}>{instrument}</div>

--- a/src/components/equipment/EquipmentBookingInfo.tsx
+++ b/src/components/equipment/EquipmentBookingInfo.tsx
@@ -1,6 +1,9 @@
 import { makeStyles } from '@material-ui/core';
 import React from 'react';
 
+import { isDraftEvent } from 'components/calendar/Event';
+import { ProposalBooking } from 'generated/sdk';
+
 const useStyles = makeStyles(() => ({
   container: {
     padding: '10px 5px 5px 5px ',
@@ -20,17 +23,22 @@ interface EquipmentBookingInfoProps {
   name: string;
   scheduledBy: string;
   instrument: string;
+  proposalBooking?: Pick<ProposalBooking, 'status'> | null;
 }
 function EquipmentBookingInfo({
   name,
   scheduledBy,
   instrument,
+  proposalBooking,
 }: EquipmentBookingInfoProps) {
   const classes = useStyles();
 
   return (
     <div className={classes.container}>
-      <strong>{name}</strong>
+      <strong>
+        {isDraftEvent(proposalBooking) ? '[DRAFT] - ' : ''}
+        {name}
+      </strong>
       <div className={classes.title}>{instrument}</div>
       <div className={classes.bookedBy}>{scheduledBy}</div>
     </div>

--- a/src/components/proposalBooking/ProposalBookingInfo.tsx
+++ b/src/components/proposalBooking/ProposalBookingInfo.tsx
@@ -1,7 +1,7 @@
 import { makeStyles } from '@material-ui/core';
 import React from 'react';
 
-import { BasicProposalBooking } from 'components/calendar/Event';
+import { BasicProposalBooking, isDraftEvent } from 'components/calendar/Event';
 
 const useStyles = makeStyles(() => ({
   container: {
@@ -37,7 +37,10 @@ function ProposalBookingInfo({ booking }: ProposalBookingInfoProps) {
 
   return (
     <div className={classes.container}>
-      <strong>{proposal.shortCode}</strong>
+      <strong>
+        {isDraftEvent(booking) ? '[DRAFT] - ' : ''}
+        {proposal.shortCode}
+      </strong>
       <div className={classes.title}>{proposal.title}</div>
       <div className={classes.proposer}>
         {`${proposal.proposer?.firstname} ${proposal.proposer?.lastname}`}

--- a/src/components/proposalBooking/ProposalBookingInfo.tsx
+++ b/src/components/proposalBooking/ProposalBookingInfo.tsx
@@ -1,7 +1,11 @@
 import { makeStyles } from '@material-ui/core';
 import React from 'react';
 
-import { BasicProposalBooking, isDraftEvent } from 'components/calendar/Event';
+import {
+  BasicProposalBooking,
+  isDraftEvent,
+  isClosedEvent,
+} from 'components/calendar/Event';
 
 const useStyles = makeStyles(() => ({
   container: {
@@ -38,7 +42,8 @@ function ProposalBookingInfo({ booking }: ProposalBookingInfoProps) {
   return (
     <div className={classes.container}>
       <strong>
-        {isDraftEvent(booking) ? '[DRAFT] - ' : ''}
+        {isDraftEvent(booking) ? '[Draft] - ' : ''}
+        {isClosedEvent(booking) ? '[Closed] - ' : ''}
         {proposal.shortCode}
       </strong>
       <div className={classes.title}>{proposal.title}</div>

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -1554,7 +1554,8 @@ export enum PageName {
   HELPPAGE = 'HELPPAGE',
   PRIVACYPAGE = 'PRIVACYPAGE',
   COOKIEPAGE = 'COOKIEPAGE',
-  REVIEWPAGE = 'REVIEWPAGE'
+  REVIEWPAGE = 'REVIEWPAGE',
+  FOOTERCONTENT = 'FOOTERCONTENT'
 }
 
 export type PageResponseWrap = {
@@ -2536,7 +2537,7 @@ export type ScheduledEvent = {
   scheduledBy: Maybe<User>;
   description: Maybe<Scalars['String']>;
   instrument: Maybe<Instrument>;
-  equipmentId: Maybe<Scalars['Int']>;
+  equipmentId: Scalars['Int'];
   equipments: Array<EquipmentWithAssignmentStatus>;
   equipmentAssignmentStatus: Maybe<EquipmentAssignmentStatus>;
   proposalBooking: Maybe<ProposalBooking>;

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -654,8 +654,8 @@ export type Mutation = {
   removeMemberFromSep: SepResponseWrap;
   assignSepReviewersToProposal: SepResponseWrap;
   removeMemberFromSEPProposal: SepResponseWrap;
-  assignProposalToSEP: NextProposalStatusResponseWrap;
-  removeProposalAssignment: SepResponseWrap;
+  assignProposalsToSep: NextProposalStatusResponseWrap;
+  removeProposalsFromSep: SepResponseWrap;
   createSEP: SepResponseWrap;
   reorderSepMeetingDecisionProposals: SepMeetingDecisionResponseWrap;
   saveSepMeetingDecision: SepMeetingDecisionResponseWrap;
@@ -1007,14 +1007,14 @@ export type MutationRemoveMemberFromSepProposalArgs = {
 };
 
 
-export type MutationAssignProposalToSepArgs = {
-  proposalId: Scalars['Int'];
+export type MutationAssignProposalsToSepArgs = {
+  proposals: Array<ProposalIdWithCallId>;
   sepId: Scalars['Int'];
 };
 
 
-export type MutationRemoveProposalAssignmentArgs = {
-  proposalId: Scalars['Int'];
+export type MutationRemoveProposalsFromSepArgs = {
+  proposalIds: Array<Scalars['Int']>;
   sepId: Scalars['Int'];
 };
 
@@ -1764,6 +1764,7 @@ export type ProposalView = {
   instrumentName: Maybe<Scalars['String']>;
   callShortCode: Maybe<Scalars['String']>;
   sepCode: Maybe<Scalars['String']>;
+  sepId: Maybe<Scalars['Int']>;
   reviewAverage: Maybe<Scalars['Float']>;
   reviewDeviation: Maybe<Scalars['Float']>;
   instrumentId: Maybe<Scalars['Int']>;
@@ -3327,9 +3328,14 @@ export type GetEquipmentScheduledEventsQuery = (
       & Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt' | 'equipmentAssignmentStatus' | 'equipmentId'>
       & { proposalBooking: Maybe<(
         { __typename?: 'ProposalBooking' }
+        & Pick<ProposalBooking, 'status'>
         & { proposal: Maybe<(
           { __typename?: 'Proposal' }
           & Pick<Proposal, 'id' | 'title' | 'shortCode'>
+          & { proposer: Maybe<(
+            { __typename?: 'BasicUserDetails' }
+            & Pick<BasicUserDetails, 'firstname' | 'lastname'>
+          )> }
         )> }
       )>, instrument: Maybe<(
         { __typename?: 'Instrument' }
@@ -3740,10 +3746,15 @@ export const GetEquipmentScheduledEventsDocument = gql`
       equipmentAssignmentStatus
       equipmentId
       proposalBooking {
+        status
         proposal {
           id
           title
           shortCode
+          proposer {
+            firstname
+            lastname
+          }
         }
       }
       instrument {

--- a/src/graphql/scheduledEvent/getEquipmentScheduledEvents.graphql
+++ b/src/graphql/scheduledEvent/getEquipmentScheduledEvents.graphql
@@ -13,10 +13,15 @@ query getEquipmentScheduledEvents(
       equipmentAssignmentStatus
       equipmentId
       proposalBooking {
+        status
         proposal {
           id
           title
           shortCode
+          proposer {
+            firstname
+            lastname
+          }
         }
       }
       instrument {


### PR DESCRIPTION
## Description

Add opacity to draft events and use gray color for closed events.

## How Has This Been Tested

e2e tests
manual tests

## Fixes

https://jira.esss.lu.se/browse/SWAP-1625

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
