### PR TITLE
patch: css styling to utilize limited space in calendar better

### DIFF
--- a/src/components/equipment/EquipmentBookingInfo.tsx
+++ b/src/components/equipment/EquipmentBookingInfo.tsx
@@ -3,16 +3,26 @@ import React from 'react';
 
 const useStyles = makeStyles(() => ({
   container: {
-    padding: '10px 5px 5px 5px ',
+    paddingTop: '3px',
+    display: 'flex',
+    flexWrap: 'wrap',
+  },
+  name: {
+    fontSize: 12,
+    fontWeight: 'bold',
+    minWidth: '100%',
+    flexGrow: 1,
   },
   title: {
-    fontSize: 15,
-    padding: '5px 0',
+    fontSize: 12,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    padding: '1px 2px 0 0',
   },
   bookedBy: {
     fontSize: 12,
-    padding: '5px 0',
     fontStyle: 'italic',
+    padding: '1px 2px 0 0',
   },
 }));
 
@@ -30,7 +40,7 @@ function EquipmentBookingInfo({
 
   return (
     <div className={classes.container}>
-      <strong>{name}</strong>
+      <div className={classes.name}>{name}</div>
       <div className={classes.title}>{instrument}</div>
       <div className={classes.bookedBy}>{scheduledBy}</div>
     </div>

--- a/src/components/proposalBooking/ProposalBookingInfo.tsx
+++ b/src/components/proposalBooking/ProposalBookingInfo.tsx
@@ -5,22 +5,27 @@ import { BasicProposalBooking } from 'components/calendar/Event';
 
 const useStyles = makeStyles(() => ({
   container: {
-    padding: '10px 5px 5px 5px ',
+    paddingTop: '3px',
+    display: 'flex',
+    flexWrap: 'wrap',
   },
 
   shortCode: {
     fontSize: 12,
     fontWeight: 'bold',
-    padding: '5px 0',
+    minWidth: '100%',
+    flexGrow: 1,
   },
   title: {
-    fontSize: 15,
-    padding: '5px 0',
+    fontSize: 12,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    padding: '1px 2px 0 0',
   },
   proposer: {
     fontSize: 12,
-    padding: '5px 0',
     fontStyle: 'italic',
+    padding: '1px 2px 0 0',
   },
 }));
 
@@ -37,7 +42,7 @@ function ProposalBookingInfo({ booking }: ProposalBookingInfoProps) {
 
   return (
     <div className={classes.container}>
-      <strong>{proposal.shortCode}</strong>
+      <div className={classes.shortCode}>{proposal.shortCode}</div>
       <div className={classes.title}>{proposal.title}</div>
       <div className={classes.proposer}>
         {`${proposal.proposer?.firstname} ${proposal.proposer?.lastname}`}


### PR DESCRIPTION
## Description

This PR adjusts CSS so that limited space in the calendar booking events are utilized better when switching between week and month view

![image](https://user-images.githubusercontent.com/58165815/122267783-f9df6f80-cee3-11eb-9cf3-3d7bd6b0fee2.png)

![image](https://user-images.githubusercontent.com/58165815/122267820-02d04100-cee4-11eb-8259-e2f2b97b6cc7.png)

## Fixes

SWAP-1634

## Depends on

N/A
