### PR TITLE
refactor: Rename proposal shortcode to proposal ID (BREAKING CHANGE)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3490,9 +3490,9 @@
       "integrity": "sha512-neI5uzO0jGWIINQT8E77P6UiPeCSc10+Hqye3rfbVixzJo1GX8+HIbYgy6eU80QgcRUIl35fFg2vlSouH8v3kw=="
     },
     "@esss-swap/duo-validation": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@esss-swap/duo-validation/-/duo-validation-1.2.6.tgz",
-      "integrity": "sha512-hAMK/wa1j81pt5+uXIdcIp49d/kxJN5B88ArOdr8fhD1VpsoYBs4ANdGeWpQOvnN0H+aAtblXh1/QWTpM477GQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@esss-swap/duo-validation/-/duo-validation-2.0.0.tgz",
+      "integrity": "sha512-sNv4k7aNvGIWCghFtLb1nLEDHJ0UU5HKFCC5cJwYXvSirV1AdfH6rGFb3Ab2L4/b/ZWlZwbHiD5IF4WpvCHPaw==",
       "requires": {
         "moment": "^2.29.0",
         "yup": "^0.29.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3490,9 +3490,9 @@
       "integrity": "sha512-neI5uzO0jGWIINQT8E77P6UiPeCSc10+Hqye3rfbVixzJo1GX8+HIbYgy6eU80QgcRUIl35fFg2vlSouH8v3kw=="
     },
     "@esss-swap/duo-validation": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@esss-swap/duo-validation/-/duo-validation-2.0.2.tgz",
-      "integrity": "sha512-KQkm3uDwQgSgVPvFX67Nu7tckoVA3cqYmVdk+ra37p6uVfw2YBzn1/QBjkvmAb/XtgO/Fvf/w4zGo01SYd6UDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@esss-swap/duo-validation/-/duo-validation-2.0.3.tgz",
+      "integrity": "sha512-mf/dkE7bQtIgPO3RXGIze26u3vK6+8mTnpy5464KrP5G3uv1nj9iSoyYqb3EwiOhKyKZpsT3QOiE8EpVlf3MLQ==",
       "requires": {
         "moment": "^2.29.0",
         "yup": "^0.29.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3490,9 +3490,9 @@
       "integrity": "sha512-neI5uzO0jGWIINQT8E77P6UiPeCSc10+Hqye3rfbVixzJo1GX8+HIbYgy6eU80QgcRUIl35fFg2vlSouH8v3kw=="
     },
     "@esss-swap/duo-validation": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@esss-swap/duo-validation/-/duo-validation-2.0.0.tgz",
-      "integrity": "sha512-sNv4k7aNvGIWCghFtLb1nLEDHJ0UU5HKFCC5cJwYXvSirV1AdfH6rGFb3Ab2L4/b/ZWlZwbHiD5IF4WpvCHPaw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@esss-swap/duo-validation/-/duo-validation-2.0.1.tgz",
+      "integrity": "sha512-3vITT4wS+yLcNl01EXx/zV4T673Ih+aBgkE6MY9X8Scr4Ky7XhlMOnuNNFADFlmbTcnqlEIyPWbJo4E3SJLn5Q==",
       "requires": {
         "moment": "^2.29.0",
         "yup": "^0.29.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3490,9 +3490,9 @@
       "integrity": "sha512-neI5uzO0jGWIINQT8E77P6UiPeCSc10+Hqye3rfbVixzJo1GX8+HIbYgy6eU80QgcRUIl35fFg2vlSouH8v3kw=="
     },
     "@esss-swap/duo-validation": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@esss-swap/duo-validation/-/duo-validation-2.0.3.tgz",
-      "integrity": "sha512-mf/dkE7bQtIgPO3RXGIze26u3vK6+8mTnpy5464KrP5G3uv1nj9iSoyYqb3EwiOhKyKZpsT3QOiE8EpVlf3MLQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@esss-swap/duo-validation/-/duo-validation-2.0.4.tgz",
+      "integrity": "sha512-wbLSlZQXCpLLkMFHXpx20OHlaqgXNyNV3kykwCxVtZl7ucjdB2EteBhxsgZX0SycSphhaCOR1gN4e4HFyPST8A==",
       "requires": {
         "moment": "^2.29.0",
         "yup": "^0.29.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3490,9 +3490,9 @@
       "integrity": "sha512-neI5uzO0jGWIINQT8E77P6UiPeCSc10+Hqye3rfbVixzJo1GX8+HIbYgy6eU80QgcRUIl35fFg2vlSouH8v3kw=="
     },
     "@esss-swap/duo-validation": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@esss-swap/duo-validation/-/duo-validation-2.0.1.tgz",
-      "integrity": "sha512-3vITT4wS+yLcNl01EXx/zV4T673Ih+aBgkE6MY9X8Scr4Ky7XhlMOnuNNFADFlmbTcnqlEIyPWbJo4E3SJLn5Q==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@esss-swap/duo-validation/-/duo-validation-2.0.2.tgz",
+      "integrity": "sha512-KQkm3uDwQgSgVPvFX67Nu7tckoVA3cqYmVdk+ra37p6uVfw2YBzn1/QBjkvmAb/XtgO/Fvf/w4zGo01SYd6UDQ==",
       "requires": {
         "moment": "^2.29.0",
         "yup": "^0.29.1"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@date-io/moment": "^1.3.13",
     "@esss-swap/duo-localisation": "^1.1.15",
-    "@esss-swap/duo-validation": "^2.0.3",
+    "@esss-swap/duo-validation": "^2.0.4",
     "@graphql-codegen/cli": "^1.21.4",
     "@graphql-codegen/typescript": "^1.22.0",
     "@graphql-codegen/typescript-graphql-request": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "private": true,
   "scripts": {
-    "dev": "react-scripts start",
+    "dev": "PORT=33000 react-scripts start",
     "build": "react-scripts --max_old_space_size=4096 build",
     "eject": "react-scripts eject",
     "lint": "tsc --noEmit && eslint . --ext .js,.jsx,.ts,.tsx --quiet",
@@ -20,7 +20,7 @@
   "dependencies": {
     "@date-io/moment": "^1.3.13",
     "@esss-swap/duo-localisation": "^1.1.15",
-    "@esss-swap/duo-validation": "^1.2.6",
+    "@esss-swap/duo-validation": "^2.0.1",
     "@graphql-codegen/cli": "^1.21.4",
     "@graphql-codegen/typescript": "^1.22.0",
     "@graphql-codegen/typescript-graphql-request": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@date-io/moment": "^1.3.13",
     "@esss-swap/duo-localisation": "^1.1.15",
-    "@esss-swap/duo-validation": "^2.0.2",
+    "@esss-swap/duo-validation": "^2.0.3",
     "@graphql-codegen/cli": "^1.21.4",
     "@graphql-codegen/typescript": "^1.22.0",
     "@graphql-codegen/typescript-graphql-request": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@date-io/moment": "^1.3.13",
     "@esss-swap/duo-localisation": "^1.1.15",
-    "@esss-swap/duo-validation": "^2.0.1",
+    "@esss-swap/duo-validation": "^2.0.2",
     "@graphql-codegen/cli": "^1.21.4",
     "@graphql-codegen/typescript": "^1.22.0",
     "@graphql-codegen/typescript-graphql-request": "^2.0.3",

--- a/src/components/proposalBooking/ProposalBookingInfo.tsx
+++ b/src/components/proposalBooking/ProposalBookingInfo.tsx
@@ -14,7 +14,7 @@ const useStyles = makeStyles(() => ({
     flexWrap: 'wrap',
   },
 
-  shortCode: {
+  proposalId: {
     fontSize: 12,
     fontWeight: 'bold',
     minWidth: '100%',
@@ -46,10 +46,10 @@ function ProposalBookingInfo({ booking }: ProposalBookingInfoProps) {
 
   return (
     <div className={classes.container}>
-      <div className={classes.shortCode}>
+      <div className={classes.proposalId}>
         {isDraftEvent(booking) ? '[Draft] - ' : ''}
         {isClosedEvent(booking) ? '[Closed] - ' : ''}
-        {proposal.shortCode}
+        {proposal.proposalId}
       </div>
       <div className={classes.title}>{proposal.title}</div>
       <div className={classes.proposer}>

--- a/src/components/proposalBooking/ProposalBookingTree.tsx
+++ b/src/components/proposalBooking/ProposalBookingTree.tsx
@@ -69,7 +69,7 @@ export default function ProposalBookingTree({
           id: `call-${id}`, // avoid numerical ID collision
           title: `Call: ${proposalBookings[0].call.shortCode}`,
           children: proposalBookings.map((proposalBooking) => ({
-            id: `proposal-${proposalBooking.proposal.id}`, // avoid numerical ID collision
+            id: `proposal-${proposalBooking.proposal.primaryKey}`, // avoid numerical ID collision
             title: (
               <ProposalBookingTreeTitle proposalBooking={proposalBooking} />
             ),

--- a/src/components/requests/ViewRequests.tsx
+++ b/src/components/requests/ViewRequests.tsx
@@ -18,7 +18,7 @@ type TableRow = {
   equipmentName: string;
   instrumentName?: string;
   proposalTitle?: string;
-  proposalShortCode?: string;
+  proposalId?: string;
   startsAt: Moment;
   endsAt: Moment;
   equipmentId?: number | null;
@@ -30,7 +30,7 @@ export const defaultHeadCells: HeadCell<TableRow>[] = [
   { id: 'equipmentName', label: 'Equipment name' },
   { id: 'instrumentName', label: 'Instrument' },
   { id: 'proposalTitle', label: 'Proposal' },
-  { id: 'proposalShortCode', label: 'Proposal ID' },
+  { id: 'proposalId', label: 'Proposal ID' },
   { id: 'startsAt', label: 'Starts at' },
   { id: 'endsAt', label: 'Ends at' },
   { id: 'equipmentAssignmentStatus', label: 'Status' },
@@ -74,7 +74,7 @@ export default function ViewRequests() {
               equipmentName: scheduledEvent.name,
               instrumentName: instrument?.name,
               proposalTitle: proposalBooking?.proposal?.title,
-              proposalShortCode: proposalBooking?.proposal?.shortCode,
+              proposalId: proposalBooking?.proposal?.proposalId,
               scheduledBy: `${scheduledBy?.firstname} ${scheduledBy?.lastname}`,
             })
           )
@@ -195,9 +195,7 @@ export default function ViewRequests() {
                       <TableCell align="left">{row.equipmentName}</TableCell>
                       <TableCell align="left">{row.instrumentName}</TableCell>
                       <TableCell align="left">{row.proposalTitle}</TableCell>
-                      <TableCell align="left">
-                        {row.proposalShortCode}
-                      </TableCell>
+                      <TableCell align="left">{row.proposalId}</TableCell>
                       <TableCell align="left">
                         {toTzLessDateTime(row.startsAt)}
                       </TableCell>

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -35,7 +35,7 @@ export type AddStatusChangingEventsToConnectionInput = {
 };
 
 export type AddTechnicalReviewInput = {
-  proposalID: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   comment?: Maybe<Scalars['String']>;
   publicComment?: Maybe<Scalars['String']>;
   timeAllocation?: Maybe<Scalars['Int']>;
@@ -49,6 +49,11 @@ export type AddUserRoleResponseWrap = {
   rejection: Maybe<Rejection>;
   success: Maybe<Scalars['Boolean']>;
 };
+
+export enum AllocationTimeUnits {
+  DAY = 'Day',
+  HOUR = 'Hour'
+}
 
 export type Answer = {
   __typename?: 'Answer';
@@ -164,6 +169,7 @@ export type Call = {
   cycleComment: Scalars['String'];
   surveyComment: Scalars['String'];
   proposalWorkflowId: Maybe<Scalars['Int']>;
+  allocationTimeUnit: AllocationTimeUnits;
   templateId: Maybe<Scalars['Int']>;
   instruments: Array<InstrumentWithAvailabilityTime>;
   proposalWorkflow: Maybe<ProposalWorkflow>;
@@ -187,7 +193,7 @@ export type CallsFilter = {
 
 export type ChangeProposalsStatusInput = {
   statusId: Scalars['Int'];
-  proposals: Array<ProposalIdWithCallId>;
+  proposals: Array<ProposalPkWithCallId>;
 };
 
 export type CheckExternalTokenWrap = {
@@ -228,6 +234,7 @@ export type CreateCallInput = {
   proposalSequence?: Maybe<Scalars['Int']>;
   cycleComment: Scalars['String'];
   surveyComment: Scalars['String'];
+  allocationTimeUnit: AllocationTimeUnits;
   proposalWorkflowId?: Maybe<Scalars['Int']>;
   templateId?: Maybe<Scalars['Int']>;
 };
@@ -795,13 +802,13 @@ export type MutationChangeProposalsStatusArgs = {
 
 
 export type MutationAssignProposalsToInstrumentArgs = {
-  proposals: Array<ProposalIdWithCallId>;
+  proposals: Array<ProposalPkWithCallId>;
   instrumentId: Scalars['Int'];
 };
 
 
 export type MutationRemoveProposalsFromInstrumentArgs = {
-  proposalIds: Array<Scalars['Int']>;
+  proposalPks: Array<Scalars['Int']>;
 };
 
 
@@ -943,7 +950,7 @@ export type MutationAddReviewArgs = {
 
 export type MutationAddUserForReviewArgs = {
   userID: Scalars['Int'];
-  proposalID: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   sepID: Scalars['Int'];
 };
 
@@ -955,14 +962,14 @@ export type MutationSubmitProposalsReviewArgs = {
 
 export type MutationUpdateTechnicalReviewAssigneeArgs = {
   userId: Scalars['Int'];
-  proposalIds: Array<Scalars['Int']>;
+  proposalPks: Array<Scalars['Int']>;
 };
 
 
 export type MutationCreateSampleArgs = {
   title: Scalars['String'];
   templateId: Scalars['Int'];
-  proposalId: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   questionId: Scalars['String'];
 };
 
@@ -996,25 +1003,25 @@ export type MutationRemoveMemberFromSepArgs = {
 export type MutationAssignSepReviewersToProposalArgs = {
   memberIds: Array<Scalars['Int']>;
   sepId: Scalars['Int'];
-  proposalId: Scalars['Int'];
+  proposalPk: Scalars['Int'];
 };
 
 
 export type MutationRemoveMemberFromSepProposalArgs = {
   memberId: Scalars['Int'];
   sepId: Scalars['Int'];
-  proposalId: Scalars['Int'];
+  proposalPk: Scalars['Int'];
 };
 
 
 export type MutationAssignProposalsToSepArgs = {
-  proposals: Array<ProposalIdWithCallId>;
+  proposals: Array<ProposalPkWithCallId>;
   sepId: Scalars['Int'];
 };
 
 
 export type MutationRemoveProposalsFromSepArgs = {
-  proposalIds: Array<Scalars['Int']>;
+  proposalPks: Array<Scalars['Int']>;
   sepId: Scalars['Int'];
 };
 
@@ -1048,20 +1055,20 @@ export type MutationUpdateSepArgs = {
 
 export type MutationUpdateSepTimeAllocationArgs = {
   sepId: Scalars['Int'];
-  proposalId: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   sepTimeAllocation?: Maybe<Scalars['Int']>;
 };
 
 
 export type MutationCreateShipmentArgs = {
   title: Scalars['String'];
-  proposalId: Scalars['Int'];
+  proposalPk: Scalars['Int'];
 };
 
 
 export type MutationUpdateShipmentArgs = {
   shipmentId: Scalars['Int'];
-  proposalId?: Maybe<Scalars['Int']>;
+  proposalPk?: Maybe<Scalars['Int']>;
   title?: Maybe<Scalars['String']>;
   status?: Maybe<ShipmentStatus>;
   externalRef?: Maybe<Scalars['String']>;
@@ -1265,7 +1272,7 @@ export type MutationCreateProposalArgs = {
 
 
 export type MutationCreateVisitArgs = {
-  proposalId: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   team?: Maybe<Array<Scalars['Int']>>;
 };
 
@@ -1429,7 +1436,7 @@ export type MutationUpdatePasswordArgs = {
 export type MutationUpdateVisitArgs = {
   visitId: Scalars['Int'];
   status?: Maybe<VisitStatus>;
-  proposalId?: Maybe<Scalars['Int']>;
+  proposalPk?: Maybe<Scalars['Int']>;
   team?: Maybe<Array<Scalars['Int']>>;
 };
 
@@ -1609,6 +1616,7 @@ export type Proposal = {
   questionary: Maybe<Questionary>;
   sepMeetingDecision: Maybe<SepMeetingDecision>;
   samples: Maybe<Array<Sample>>;
+  visits: Maybe<Array<Visit>>;
   proposalBooking: Maybe<ProposalBooking>;
 };
 
@@ -1676,18 +1684,18 @@ export type ProposalEvent = {
   description: Maybe<Scalars['String']>;
 };
 
-export type ProposalIdWithCallId = {
+export type ProposalPkWithCallId = {
   id: Scalars['Int'];
   callId: Scalars['Int'];
 };
 
-export type ProposalIdWithRankOrder = {
-  proposalId: Scalars['Int'];
+export type ProposalPkWithRankOrder = {
+  proposalPk: Scalars['Int'];
   rankOrder: Scalars['Int'];
 };
 
-export type ProposalIdWithReviewId = {
-  proposalId: Scalars['Int'];
+export type ProposalPkWithReviewId = {
+  proposalPk: Scalars['Int'];
   reviewId: Scalars['Int'];
 };
 
@@ -1770,6 +1778,7 @@ export type ProposalView = {
   reviewDeviation: Maybe<Scalars['Float']>;
   instrumentId: Maybe<Scalars['Int']>;
   callId: Scalars['Int'];
+  allocationTimeUnit: AllocationTimeUnits;
 };
 
 export type ProposalWorkflow = {
@@ -2047,7 +2056,7 @@ export type QueryInstrumentScientistHasInstrumentArgs = {
 
 
 export type QueryInstrumentScientistHasAccessArgs = {
-  proposalId: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   instrumentId: Scalars['Int'];
 };
 
@@ -2063,7 +2072,7 @@ export type QueryProposalArgs = {
 
 
 export type QueryUserHasAccessToProposalArgs = {
-  proposalId: Scalars['Int'];
+  proposalPk: Scalars['Int'];
 };
 
 
@@ -2099,7 +2108,7 @@ export type QueryReviewArgs = {
 
 
 export type QueryProposalReviewsArgs = {
-  proposalId: Scalars['Int'];
+  proposalPk: Scalars['Int'];
 };
 
 
@@ -2140,7 +2149,7 @@ export type QuerySepProposalsArgs = {
 
 
 export type QuerySepProposalArgs = {
-  proposalId: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   sepId: Scalars['Int'];
 };
 
@@ -2345,7 +2354,7 @@ export type RemoveAssignedInstrumentFromCallInput = {
 };
 
 export type ReorderSepMeetingDecisionProposalsInput = {
-  proposals: Array<ProposalIdWithRankOrder>;
+  proposals: Array<ProposalPkWithRankOrder>;
 };
 
 export type Review = {
@@ -2423,7 +2432,7 @@ export type Sep = {
 
 export type SepAssignment = {
   __typename?: 'SEPAssignment';
-  proposalId: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   sepMemberUserId: Maybe<Scalars['Int']>;
   sepId: Scalars['Int'];
   dateAssigned: Scalars['DateTime'];
@@ -2438,7 +2447,7 @@ export type SepAssignment = {
 
 export type SepProposal = {
   __typename?: 'SEPProposal';
-  proposalId: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   sepId: Scalars['Int'];
   dateAssigned: Scalars['DateTime'];
   sepTimeAllocation: Maybe<Scalars['Int']>;
@@ -2479,7 +2488,7 @@ export type Sample = {
   title: Scalars['String'];
   creatorId: Scalars['Int'];
   questionaryId: Scalars['Int'];
-  proposalId: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   questionId: Scalars['String'];
   safetyStatus: SampleStatus;
   safetyComment: Scalars['String'];
@@ -2513,11 +2522,11 @@ export type SamplesFilter = {
   sampleIds?: Maybe<Array<Scalars['Int']>>;
   status?: Maybe<SampleStatus>;
   questionId?: Maybe<Scalars['String']>;
-  proposalId?: Maybe<Scalars['Int']>;
+  proposalPk?: Maybe<Scalars['Int']>;
 };
 
 export type SaveSepMeetingDecisionInput = {
-  proposalId: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   commentForUser?: Maybe<Scalars['String']>;
   commentForManagement?: Maybe<Scalars['String']>;
   recommendation?: Maybe<ProposalEndStatus>;
@@ -2537,7 +2546,7 @@ export type ScheduledEvent = {
   scheduledBy: Maybe<User>;
   description: Maybe<Scalars['String']>;
   instrument: Maybe<Instrument>;
-  equipmentId: Scalars['Int'];
+  equipmentId: Maybe<Scalars['Int']>;
   equipments: Array<EquipmentWithAssignmentStatus>;
   equipmentAssignmentStatus: Maybe<EquipmentAssignmentStatus>;
   proposalBooking: Maybe<ProposalBooking>;
@@ -2586,7 +2595,7 @@ export type SelectionFromOptionsConfig = {
 
 export type SepMeetingDecision = {
   __typename?: 'SepMeetingDecision';
-  proposalId: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   recommendation: Maybe<ProposalEndStatus>;
   commentForManagement: Maybe<Scalars['String']>;
   commentForUser: Maybe<Scalars['String']>;
@@ -2616,7 +2625,7 @@ export type Shipment = {
   __typename?: 'Shipment';
   id: Scalars['Int'];
   title: Scalars['String'];
-  proposalId: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   status: ShipmentStatus;
   externalRef: Maybe<Scalars['String']>;
   questionaryId: Scalars['Int'];
@@ -2648,7 +2657,7 @@ export enum ShipmentStatus {
 export type ShipmentsFilter = {
   title?: Maybe<Scalars['String']>;
   creatorId?: Maybe<Scalars['Int']>;
-  proposalId?: Maybe<Scalars['Int']>;
+  proposalPk?: Maybe<Scalars['Int']>;
   questionaryIds?: Maybe<Array<Scalars['Int']>>;
   status?: Maybe<ShipmentStatus>;
   externalRef?: Maybe<Scalars['String']>;
@@ -2677,11 +2686,11 @@ export type StatusChangingEvent = {
 };
 
 export type SubmitProposalsReviewInput = {
-  proposals: Array<ProposalIdWithReviewId>;
+  proposals: Array<ProposalPkWithReviewId>;
 };
 
 export type SubmitTechnicalReviewInput = {
-  proposalID: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   comment?: Maybe<Scalars['String']>;
   publicComment?: Maybe<Scalars['String']>;
   timeAllocation?: Maybe<Scalars['Int']>;
@@ -2710,7 +2719,7 @@ export type SuccessResponseWrap = {
 export type TechnicalReview = {
   __typename?: 'TechnicalReview';
   id: Scalars['Int'];
-  proposalID: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   comment: Maybe<Scalars['String']>;
   publicComment: Maybe<Scalars['String']>;
   timeAllocation: Maybe<Scalars['Int']>;
@@ -2855,6 +2864,7 @@ export type UpdateCallInput = {
   proposalSequence?: Maybe<Scalars['Int']>;
   cycleComment: Scalars['String'];
   surveyComment: Scalars['String'];
+  allocationTimeUnit: AllocationTimeUnits;
   proposalWorkflowId?: Maybe<Scalars['Int']>;
   callEnded?: Maybe<Scalars['Int']>;
   callReviewEnded?: Maybe<Scalars['Int']>;
@@ -2917,7 +2927,13 @@ export type UserReviewsArgs = {
 
 
 export type UserProposalsArgs = {
+  filter?: Maybe<UserProposalsFilter>;
+};
+
+export type UserProposalsFilter = {
   instrumentId?: Maybe<Scalars['Int']>;
+  managementDecisionSubmitted?: Maybe<Scalars['Boolean']>;
+  finalStatus?: Maybe<ProposalEndStatus>;
 };
 
 export type UserQueryResult = {
@@ -2945,10 +2961,9 @@ export enum UserRole {
 export type Visit = {
   __typename?: 'Visit';
   id: Scalars['Int'];
-  proposalId: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   status: VisitStatus;
   questionaryId: Scalars['Int'];
-  instrumentId: Scalars['Int'];
   visitorId: Scalars['Int'];
   proposal: Proposal;
   team: Array<BasicUserDetails>;
@@ -2977,6 +2992,7 @@ export enum VisitStatus {
 export type VisitsFilter = {
   visitorId?: Maybe<Scalars['Int']>;
   questionaryId?: Maybe<Scalars['Int']>;
+  proposalPk?: Maybe<Scalars['Int']>;
 };
 
 export type AddEquipmentResponsibleMutationVariables = Exact<{

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -204,7 +204,7 @@ export type CheckExternalTokenWrap = {
 
 export type CloneProposalInput = {
   callId: Scalars['Int'];
-  proposalToCloneId: Scalars['Int'];
+  proposalToClonePk: Scalars['Int'];
 };
 
 export type ConfirmEquipmentAssignmentInput = {
@@ -856,7 +856,7 @@ export type MutationSubmitInstrumentArgs = {
 
 
 export type MutationAdministrationProposalArgs = {
-  primaryKey: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   commentForUser?: Maybe<Scalars['String']>;
   commentForManagement?: Maybe<Scalars['String']>;
   finalStatus?: Maybe<ProposalEndStatus>;
@@ -1293,7 +1293,7 @@ export type MutationDeleteInstrumentArgs = {
 
 
 export type MutationDeleteProposalArgs = {
-  id: Scalars['Int'];
+  proposalPk: Scalars['Int'];
 };
 
 
@@ -1402,7 +1402,7 @@ export type MutationDeleteProposalWorkflowArgs = {
 
 
 export type MutationSubmitProposalArgs = {
-  id: Scalars['Int'];
+  proposalPk: Scalars['Int'];
 };
 
 

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -872,7 +872,7 @@ export type MutationCloneProposalArgs = {
 
 
 export type MutationUpdateProposalArgs = {
-  primaryKey: Scalars['Int'];
+  proposalPk: Scalars['Int'];
   title?: Maybe<Scalars['String']>;
   abstract?: Maybe<Scalars['String']>;
   users?: Maybe<Array<Scalars['Int']>>;
@@ -1359,7 +1359,7 @@ export type MutationLoginArgs = {
 
 
 export type MutationNotifyProposalArgs = {
-  id: Scalars['Int'];
+  proposalPk: Scalars['Int'];
 };
 
 

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -1593,7 +1593,7 @@ export type Proposal = {
   statusId: Scalars['Int'];
   created: Scalars['DateTime'];
   updated: Scalars['DateTime'];
-  shortCode: Scalars['String'];
+  proposalId: Scalars['String'];
   finalStatus: Maybe<ProposalEndStatus>;
   callId: Scalars['Int'];
   questionaryId: Scalars['Int'];
@@ -1763,7 +1763,7 @@ export type ProposalView = {
   statusId: Scalars['Int'];
   statusName: Scalars['String'];
   statusDescription: Scalars['String'];
-  shortCode: Scalars['String'];
+  proposalId: Scalars['String'];
   rankOrder: Maybe<Scalars['Int']>;
   finalStatus: Maybe<ProposalEndStatus>;
   notified: Scalars['Boolean'];
@@ -2067,7 +2067,7 @@ export type QueryIsNaturalKeyPresentArgs = {
 
 
 export type QueryProposalArgs = {
-  id: Scalars['Int'];
+  primaryKey: Scalars['Int'];
 };
 
 
@@ -3262,7 +3262,7 @@ export type GetInstrumentProposalBookingsQuery = (
       & Pick<Call, 'id' | 'shortCode' | 'startCycle' | 'endCycle' | 'cycleComment'>
     )>, proposal: Maybe<(
       { __typename?: 'Proposal' }
-      & Pick<Proposal, 'primaryKey' | 'title' | 'shortCode'>
+      & Pick<Proposal, 'primaryKey' | 'title' | 'proposalId'>
     )>, scheduledEvents: Array<(
       { __typename?: 'ScheduledEvent' }
       & Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt'>
@@ -3286,7 +3286,7 @@ export type GetProposalBookingQuery = (
       & Pick<Call, 'id' | 'shortCode' | 'startCycle' | 'endCycle' | 'cycleComment'>
     )>, proposal: Maybe<(
       { __typename?: 'Proposal' }
-      & Pick<Proposal, 'primaryKey' | 'title' | 'shortCode'>
+      & Pick<Proposal, 'primaryKey' | 'title' | 'proposalId'>
     )>, scheduledEvents: Array<(
       { __typename?: 'ScheduledEvent' }
       & Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt'>
@@ -3348,7 +3348,7 @@ export type GetEquipmentScheduledEventsQuery = (
         & Pick<ProposalBooking, 'status'>
         & { proposal: Maybe<(
           { __typename?: 'Proposal' }
-          & Pick<Proposal, 'primaryKey' | 'title' | 'shortCode'>
+          & Pick<Proposal, 'primaryKey' | 'title' | 'proposalId'>
           & { proposer: Maybe<(
             { __typename?: 'BasicUserDetails' }
             & Pick<BasicUserDetails, 'firstname' | 'lastname'>
@@ -3418,7 +3418,7 @@ export type GetScheduledEventsQuery = (
       & Pick<ProposalBooking, 'id' | 'createdAt' | 'updatedAt' | 'status' | 'allocatedTime'>
       & { proposal: Maybe<(
         { __typename?: 'Proposal' }
-        & Pick<Proposal, 'primaryKey' | 'title' | 'shortCode'>
+        & Pick<Proposal, 'primaryKey' | 'title' | 'proposalId'>
         & { proposer: Maybe<(
           { __typename?: 'BasicUserDetails' }
           & Pick<BasicUserDetails, 'firstname' | 'lastname'>
@@ -3690,7 +3690,7 @@ export const GetInstrumentProposalBookingsDocument = gql`
     proposal {
       primaryKey
       title
-      shortCode
+      proposalId
     }
     createdAt
     updatedAt
@@ -3718,7 +3718,7 @@ export const GetProposalBookingDocument = gql`
     proposal {
       primaryKey
       title
-      shortCode
+      proposalId
     }
     scheduledEvents(filter: $filter) {
       id
@@ -3774,7 +3774,7 @@ export const GetEquipmentScheduledEventsDocument = gql`
         proposal {
           primaryKey
           title
-          shortCode
+          proposalId
           proposer {
             firstname
             lastname
@@ -3847,7 +3847,7 @@ export const GetScheduledEventsDocument = gql`
       proposal {
         primaryKey
         title
-        shortCode
+        proposalId
         proposer {
           firstname
           lastname

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -856,7 +856,7 @@ export type MutationSubmitInstrumentArgs = {
 
 
 export type MutationAdministrationProposalArgs = {
-  id: Scalars['Int'];
+  primaryKey: Scalars['Int'];
   commentForUser?: Maybe<Scalars['String']>;
   commentForManagement?: Maybe<Scalars['String']>;
   finalStatus?: Maybe<ProposalEndStatus>;
@@ -872,7 +872,7 @@ export type MutationCloneProposalArgs = {
 
 
 export type MutationUpdateProposalArgs = {
-  id: Scalars['Int'];
+  primaryKey: Scalars['Int'];
   title?: Maybe<Scalars['String']>;
   abstract?: Maybe<Scalars['String']>;
   users?: Maybe<Array<Scalars['Int']>>;
@@ -1587,7 +1587,7 @@ export type PrepareDbResponseWrap = {
 
 export type Proposal = {
   __typename?: 'Proposal';
-  id: Scalars['Int'];
+  primaryKey: Scalars['Int'];
   title: Scalars['String'];
   abstract: Scalars['String'];
   statusId: Scalars['Int'];
@@ -1685,7 +1685,7 @@ export type ProposalEvent = {
 };
 
 export type ProposalPkWithCallId = {
-  id: Scalars['Int'];
+  primaryKey: Scalars['Int'];
   callId: Scalars['Int'];
 };
 
@@ -1758,7 +1758,7 @@ export type ProposalTemplatesFilter = {
 
 export type ProposalView = {
   __typename?: 'ProposalView';
-  id: Scalars['Int'];
+  primaryKey: Scalars['Int'];
   title: Scalars['String'];
   statusId: Scalars['Int'];
   statusName: Scalars['String'];
@@ -3262,7 +3262,7 @@ export type GetInstrumentProposalBookingsQuery = (
       & Pick<Call, 'id' | 'shortCode' | 'startCycle' | 'endCycle' | 'cycleComment'>
     )>, proposal: Maybe<(
       { __typename?: 'Proposal' }
-      & Pick<Proposal, 'id' | 'title' | 'shortCode'>
+      & Pick<Proposal, 'primaryKey' | 'title' | 'shortCode'>
     )>, scheduledEvents: Array<(
       { __typename?: 'ScheduledEvent' }
       & Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt'>
@@ -3286,7 +3286,7 @@ export type GetProposalBookingQuery = (
       & Pick<Call, 'id' | 'shortCode' | 'startCycle' | 'endCycle' | 'cycleComment'>
     )>, proposal: Maybe<(
       { __typename?: 'Proposal' }
-      & Pick<Proposal, 'id' | 'title' | 'shortCode'>
+      & Pick<Proposal, 'primaryKey' | 'title' | 'shortCode'>
     )>, scheduledEvents: Array<(
       { __typename?: 'ScheduledEvent' }
       & Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt'>
@@ -3348,7 +3348,7 @@ export type GetEquipmentScheduledEventsQuery = (
         & Pick<ProposalBooking, 'status'>
         & { proposal: Maybe<(
           { __typename?: 'Proposal' }
-          & Pick<Proposal, 'id' | 'title' | 'shortCode'>
+          & Pick<Proposal, 'primaryKey' | 'title' | 'shortCode'>
           & { proposer: Maybe<(
             { __typename?: 'BasicUserDetails' }
             & Pick<BasicUserDetails, 'firstname' | 'lastname'>
@@ -3418,7 +3418,7 @@ export type GetScheduledEventsQuery = (
       & Pick<ProposalBooking, 'id' | 'createdAt' | 'updatedAt' | 'status' | 'allocatedTime'>
       & { proposal: Maybe<(
         { __typename?: 'Proposal' }
-        & Pick<Proposal, 'id' | 'title' | 'shortCode'>
+        & Pick<Proposal, 'primaryKey' | 'title' | 'shortCode'>
         & { proposer: Maybe<(
           { __typename?: 'BasicUserDetails' }
           & Pick<BasicUserDetails, 'firstname' | 'lastname'>
@@ -3688,7 +3688,7 @@ export const GetInstrumentProposalBookingsDocument = gql`
       cycleComment
     }
     proposal {
-      id
+      primaryKey
       title
       shortCode
     }
@@ -3716,7 +3716,7 @@ export const GetProposalBookingDocument = gql`
       cycleComment
     }
     proposal {
-      id
+      primaryKey
       title
       shortCode
     }
@@ -3772,7 +3772,7 @@ export const GetEquipmentScheduledEventsDocument = gql`
       proposalBooking {
         status
         proposal {
-          id
+          primaryKey
           title
           shortCode
           proposer {
@@ -3845,7 +3845,7 @@ export const GetScheduledEventsDocument = gql`
       status
       allocatedTime
       proposal {
-        id
+        primaryKey
         title
         shortCode
         proposer {

--- a/src/graphql/proposalBooking/getInstrumentProposalBookings.graphql
+++ b/src/graphql/proposalBooking/getInstrumentProposalBookings.graphql
@@ -14,7 +14,7 @@ query getInstrumentProposalBookings(
     proposal {
       primaryKey
       title
-      shortCode
+      proposalId
     }
     createdAt
     updatedAt

--- a/src/graphql/proposalBooking/getInstrumentProposalBookings.graphql
+++ b/src/graphql/proposalBooking/getInstrumentProposalBookings.graphql
@@ -12,7 +12,7 @@ query getInstrumentProposalBookings(
       cycleComment
     }
     proposal {
-      id
+      primaryKey
       title
       shortCode
     }

--- a/src/graphql/proposalBooking/getProposalBooking.graphql
+++ b/src/graphql/proposalBooking/getProposalBooking.graphql
@@ -14,7 +14,7 @@ query getProposalBooking(
     proposal {
       primaryKey
       title
-      shortCode
+      proposalId
     }
     scheduledEvents(filter: $filter) {
       id

--- a/src/graphql/proposalBooking/getProposalBooking.graphql
+++ b/src/graphql/proposalBooking/getProposalBooking.graphql
@@ -12,7 +12,7 @@ query getProposalBooking(
       cycleComment
     }
     proposal {
-      id
+      primaryKey
       title
       shortCode
     }

--- a/src/graphql/scheduledEvent/getEquipmentScheduledEvents.graphql
+++ b/src/graphql/scheduledEvent/getEquipmentScheduledEvents.graphql
@@ -15,7 +15,7 @@ query getEquipmentScheduledEvents(
       proposalBooking {
         status
         proposal {
-          id
+          primaryKey
           title
           shortCode
           proposer {

--- a/src/graphql/scheduledEvent/getEquipmentScheduledEvents.graphql
+++ b/src/graphql/scheduledEvent/getEquipmentScheduledEvents.graphql
@@ -17,7 +17,7 @@ query getEquipmentScheduledEvents(
         proposal {
           primaryKey
           title
-          shortCode
+          proposalId
           proposer {
             firstname
             lastname

--- a/src/graphql/scheduledEvent/getScheduledEvents.graphql
+++ b/src/graphql/scheduledEvent/getScheduledEvents.graphql
@@ -23,7 +23,7 @@ query getScheduledEvents(
       status
       allocatedTime
       proposal {
-        id
+        primaryKey
         title
         shortCode
         proposer {

--- a/src/graphql/scheduledEvent/getScheduledEvents.graphql
+++ b/src/graphql/scheduledEvent/getScheduledEvents.graphql
@@ -25,7 +25,7 @@ query getScheduledEvents(
       proposal {
         primaryKey
         title
-        shortCode
+        proposalId
         proposer {
           firstname
           lastname

--- a/src/hooks/proposalBooking/useInstrumentProposalBookings.ts
+++ b/src/hooks/proposalBooking/useInstrumentProposalBookings.ts
@@ -17,7 +17,7 @@ export type InstrumentProposalBooking = Pick<
     'id' | 'shortCode' | 'startCycle' | 'endCycle' | 'cycleComment'
   >;
 } & {
-  proposal: Pick<Proposal, 'id' | 'title' | 'shortCode'>;
+  proposal: Pick<Proposal, 'primaryKey' | 'title' | 'shortCode'>;
 };
 
 export default function useInstrumentProposalBookings(

--- a/src/hooks/proposalBooking/useInstrumentProposalBookings.ts
+++ b/src/hooks/proposalBooking/useInstrumentProposalBookings.ts
@@ -17,7 +17,7 @@ export type InstrumentProposalBooking = Pick<
     'id' | 'shortCode' | 'startCycle' | 'endCycle' | 'cycleComment'
   >;
 } & {
-  proposal: Pick<Proposal, 'primaryKey' | 'title' | 'shortCode'>;
+  proposal: Pick<Proposal, 'primaryKey' | 'title' | 'proposalId'>;
 };
 
 export default function useInstrumentProposalBookings(

--- a/src/hooks/proposalBooking/useProposalBooking.ts
+++ b/src/hooks/proposalBooking/useProposalBooking.ts
@@ -17,7 +17,7 @@ export type DetailedProposalBooking = Pick<
     'id' | 'shortCode' | 'startCycle' | 'endCycle' | 'cycleComment'
   >;
 } & {
-  proposal: Pick<Proposal, 'primaryKey' | 'title' | 'shortCode'>;
+  proposal: Pick<Proposal, 'primaryKey' | 'title' | 'proposalId'>;
 };
 
 export default function useProposalBooking(id: string) {

--- a/src/hooks/proposalBooking/useProposalBooking.ts
+++ b/src/hooks/proposalBooking/useProposalBooking.ts
@@ -17,7 +17,7 @@ export type DetailedProposalBooking = Pick<
     'id' | 'shortCode' | 'startCycle' | 'endCycle' | 'cycleComment'
   >;
 } & {
-  proposal: Pick<Proposal, 'id' | 'title' | 'shortCode'>;
+  proposal: Pick<Proposal, 'primaryKey' | 'title' | 'shortCode'>;
 };
 
 export default function useProposalBooking(id: string) {


### PR DESCRIPTION
## Description

![image](https://user-images.githubusercontent.com/58165815/123067365-98eef480-d419-11eb-9972-017fe3aa2547.png)

refactor: Renaming shortcode to proposal ID and proposal ID to proposal primary key

## Motivation and Context

In some places we call the 6 digit identifier as proposal ID but in others shortcode. In system it is called a shortcode, but people often refer it to as the ID. 

Because people call shortcode ID this task is to rename the shortcode to proposal_id and existing id to primary_key


## Fixes

SWAP-1629


## Depends on

https://github.com/UserOfficeProject/user-office-frontend/pull/430
https://github.com/UserOfficeProject/user-office-backend/pull/339
https://github.com/UserOfficeProject/user-office-scheduler-backend/pull/40


