### PR TITLE
SWAP-1622-move-save-button-in-equipment-assigning

### DIFF
--- a/cypress/integration/proposal-booking.spec.ts
+++ b/cypress/integration/proposal-booking.spec.ts
@@ -249,7 +249,7 @@ context('Proposal booking tests ', () => {
 
         cy.get('[data-cy=enhanced-table-checkbox-0]').click();
         cy.get('[data-cy=enhanced-table-checkbox-1]').click();
-        cy.get('[data-cy=btn-assign-all]').click();
+        cy.get('[data-cy=btn-assign-equipment]').click();
 
         cy.contains(/2020-09-21 14:00:00/);
         cy.contains(/2020-09-21 15:00:00/);

--- a/src/components/common/Table.tsx
+++ b/src/components/common/Table.tsx
@@ -274,6 +274,7 @@ export type TableProps<T extends Record<string, unknown>> = {
   extractKey: (obj: T) => string;
   onDelete?: (ids: string[]) => void;
   onPageChange?: (page: number) => void;
+  onSelectionChange?: (selected: string[]) => void;
   'data-cy'?: string;
 };
 
@@ -287,6 +288,10 @@ const labelDisplayedRows = ({ from, to, count }: LabelDisplayedRowsArgs) => {
   return `${range} of ${of}`;
 };
 
+/**
+ * TODO: Maybe we should replace this Table component with material-table.
+ * To be consistent with the core-frontend and because now it is included in the scheduler-frontend anyway.
+ */
 export default function Table<T extends { [k: string]: any }>({
   headCells,
   rows,
@@ -300,6 +305,7 @@ export default function Table<T extends { [k: string]: any }>({
   renderRow,
   extractKey,
   onPageChange,
+  onSelectionChange,
   ...rest
 }: TableProps<T>) {
   const classes = useStyles();
@@ -328,10 +334,12 @@ export default function Table<T extends { [k: string]: any }>({
     if (event.target.checked) {
       const newSelectedRows = rows.map((n) => extractKey(n));
       setSelected(newSelectedRows);
+      onSelectionChange?.(newSelectedRows);
 
       return;
     }
     setSelected([]);
+    onSelectionChange?.([]);
   };
 
   const handleClick = (_: React.MouseEvent<unknown>, key: string) => {
@@ -352,6 +360,7 @@ export default function Table<T extends { [k: string]: any }>({
     }
 
     setSelected(newSelected);
+    onSelectionChange?.(newSelected);
   };
 
   const handleChangePage = (_: unknown, newPage: number) => {
@@ -389,6 +398,7 @@ export default function Table<T extends { [k: string]: any }>({
           const onClick = () => {
             action.onClick(selected);
             action.clearSelect && setSelected([]);
+            action.clearSelect && onSelectionChange?.([]);
           };
 
           return {

--- a/src/components/equipment/ViewEquipment.tsx
+++ b/src/components/equipment/ViewEquipment.tsx
@@ -161,7 +161,7 @@ export default function ViewEquipment({ equipmentId }: ViewEquipmentProps) {
         );
       }
     }
-  }, [scheduledEventsLoading, scheduledEvents]);
+  }, [scheduledEventsLoading, scheduledEvents, equipment]);
   if (equipmentLoading) {
     return <Loader container />;
   }

--- a/src/components/proposalBooking/bookingSteps/equipmentBooking/SelectEquipmentDialog.tsx
+++ b/src/components/proposalBooking/bookingSteps/equipmentBooking/SelectEquipmentDialog.tsx
@@ -5,9 +5,8 @@ import {
   TableCell,
   Dialog,
 } from '@material-ui/core';
-import { DoneAll as DoneAllIcon } from '@material-ui/icons';
 import { useSnackbar } from 'notistack';
-import React from 'react';
+import React, { useState } from 'react';
 
 import Loader from 'components/common/Loader';
 import Table, { HeadCell } from 'components/common/Table';
@@ -44,6 +43,7 @@ export default function SelectEquipmentDialog({
   const { enqueueSnackbar } = useSnackbar();
   const api = useDataApi();
   const { equipments, loading } = useAvailableEquipments(scheduledEvent.id);
+  const [selectedEquipments, setSelectedEquipments] = useState<string[]>([]);
 
   const handleAssign = async (ids: string[]) => {
     const { assignToScheduledEvents: success } =
@@ -64,26 +64,20 @@ export default function SelectEquipmentDialog({
     success && closeDialog(true);
   };
 
-  const selectActions = [
-    {
-      tooltip: 'Assign equipment',
-      icon: <DoneAllIcon data-cy="btn-assign-all" />,
-      onClick: handleAssign,
-    },
-  ];
-
   return (
     <Dialog open={isDialogOpen} maxWidth="md" fullWidth>
       {loading && <Loader />}
       <DialogContent>
         <Table
           selectable
+          onSelectionChange={(selectedItems) =>
+            setSelectedEquipments(selectedItems)
+          }
           defaultOrderBy="name"
           tableTitle="Equipments"
           headCells={defaultHeadCells}
           tableContainerMaxHeight={600}
           showEmptyRows
-          tooltipActions={selectActions}
           rows={equipments}
           extractKey={(el) => el.id}
           renderRow={(row) => {
@@ -99,6 +93,15 @@ export default function SelectEquipmentDialog({
         />
       </DialogContent>
       <DialogActions>
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={() => handleAssign(selectedEquipments)}
+          disabled={!selectedEquipments.length}
+          data-cy="btn-assign-equipment"
+        >
+          Assign equipment
+        </Button>
         <Button color="primary" onClick={() => closeDialog()}>
           Close
         </Button>


### PR DESCRIPTION
## Description

Move assign equipment button to the bottom of the modal instead of table toolbar

## How Has This Been Tested

e2e tests
manual tests

## Fixes

https://jira.esss.lu.se/browse/SWAP-1622

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
