### PR TITLE
Swap 1688 organize bookings around timeslot

### DIFF
--- a/cypress/integration/proposal-booking.spec.ts
+++ b/cypress/integration/proposal-booking.spec.ts
@@ -161,7 +161,8 @@ context('Proposal booking tests ', () => {
 
         cy.finishedLoading();
 
-        cy.get('[data-cy=btn-time-table-edit-row]').should('exist');
+        cy.contains('Proposal allocated time');
+        cy.contains('Proposal allocatable time');
 
         cy.contains(currentHourDateTime);
         cy.contains(getHourDateTimeAfter(24));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1417,9 +1417,9 @@
       "integrity": "sha512-neI5uzO0jGWIINQT8E77P6UiPeCSc10+Hqye3rfbVixzJo1GX8+HIbYgy6eU80QgcRUIl35fFg2vlSouH8v3kw=="
     },
     "@esss-swap/duo-validation": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@esss-swap/duo-validation/-/duo-validation-2.0.8.tgz",
-      "integrity": "sha512-gfK3gCpyewNUBfOEqXPvyRpSsddYrtfvInVblr8V23WoMaFpvGL4X8TI0902DvXQt9FB7n/KYk2IubrQ7M7u3A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@esss-swap/duo-validation/-/duo-validation-2.1.0.tgz",
+      "integrity": "sha512-GWTXqSerLoHmVyyJ65syD/EGF7TpV7Xs0I0Pdvd+NLbMOAl2XoOrnUwEr0ZSEFaHRUpZLabi3Wcj7atzLc1EXw==",
       "requires": {
         "moment": "^2.29.0",
         "sanitize-html": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@date-io/moment": "^1.3.13",
     "@esss-swap/duo-localisation": "^1.1.15",
-    "@esss-swap/duo-validation": "^2.0.8",
+    "@esss-swap/duo-validation": "^2.1.0",
     "@graphql-codegen/cli": "^2.0.0",
     "@graphql-codegen/typescript": "^1.23.0",
     "@graphql-codegen/typescript-graphql-request": "^2.0.3",

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -93,6 +93,7 @@ const transformEvent = (
     proposalBooking: scheduledEvent.proposalBooking,
     instrument: scheduledEvent.instrument,
     scheduledBy: scheduledEvent.scheduledBy,
+    status: scheduledEvent.status,
   }));
 
 function isOverlapping(

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -21,11 +21,11 @@ import {
 
 import Loader from 'components/common/Loader';
 import EquipmentBookingDialog from 'components/equipment/EquipmentBookingDialog';
-import ProposalBookingDialog from 'components/proposalBooking/ProposalBookingDialog';
 import ScheduledEventDialog, {
   SlotInfo,
 } from 'components/scheduledEvent/ScheduledEventDialog';
 import { BookingTypesMap } from 'components/scheduledEvent/ScheduledEventForm';
+import TimeSlotBookingDialog from 'components/timeSlotBooking/TimeSlotBookingDialog';
 import { AppContext } from 'context/AppContext';
 import {
   ScheduledEvent,
@@ -143,9 +143,10 @@ export default function Calendar() {
   const [filter, setFilter] = useState(
     generateScheduledEventFilter(queryInstrument, startsAt, view)
   );
-  const [selectedProposalBooking, setSelectedProposalBooking] = useState<
-    string | null
-  >(null);
+  const [selectedProposalBooking, setSelectedProposalBooking] = useState<{
+    proposalBookingId: string | null;
+    scheduledEventId: string | null;
+  }>({ proposalBookingId: null, scheduledEventId: null });
   const [selectedEquipmentBooking, setSelectedEquipmentBooking] = useState<
     string | null
   >(null);
@@ -266,7 +267,10 @@ export default function Calendar() {
         );
 
         if (scheduledEvent?.proposalBooking) {
-          setSelectedProposalBooking(scheduledEvent.proposalBooking.id);
+          setSelectedProposalBooking({
+            proposalBookingId: scheduledEvent.proposalBooking.id,
+            scheduledEventId: scheduledEvent.id,
+          });
         }
         break;
       }
@@ -313,7 +317,10 @@ export default function Calendar() {
   };
 
   const handleCloseDialog = (shouldRefresh?: boolean) => {
-    setSelectedProposalBooking(null);
+    setSelectedProposalBooking({
+      scheduledEventId: null,
+      proposalBookingId: null,
+    });
     setSelectedEquipmentBooking(null);
 
     if (shouldRefresh) {
@@ -339,13 +346,19 @@ export default function Calendar() {
                 closeDialog={closeDialog}
               />
             )}
-            {selectedProposalBooking !== null && (
-              <ProposalBookingDialog
-                activeProposalBookingId={selectedProposalBooking}
-                isDialogOpen={true}
-                closeDialog={handleCloseDialog}
-              />
-            )}
+            {selectedProposalBooking.proposalBookingId !== null &&
+              selectedProposalBooking.scheduledEventId !== null && (
+                <TimeSlotBookingDialog
+                  activeTimeSlotScheduledEventId={
+                    selectedProposalBooking.scheduledEventId
+                  }
+                  activeProposalBookingId={
+                    selectedProposalBooking.proposalBookingId
+                  }
+                  isDialogOpen={true}
+                  closeDialog={handleCloseDialog}
+                />
+              )}
             {selectedEquipmentBooking !== null && (
               <EquipmentBookingDialog
                 activeEquipmentBookingId={selectedEquipmentBooking}

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -125,7 +125,9 @@ export default function Calendar() {
 
   const query = useQuery();
   const queryInstrument = query.get('instrument');
+  const queryInstrumentId = queryInstrument ? parseInt(queryInstrument) : 0;
   const queryEquipment = query.get('equipment')?.split(',');
+  const queryEquipmentNumbers = queryEquipment?.map((item) => parseInt(item));
 
   const { showAlert } = useContext(AppContext);
   const [selectedEvent, setSelectedEvent] = useState<
@@ -141,14 +143,14 @@ export default function Calendar() {
   );
   const [view, setView] = useState<ExtendedView>(CALENDAR_DEFAULT_VIEW);
   const [filter, setFilter] = useState(
-    generateScheduledEventFilter(queryInstrument, startsAt, view)
+    generateScheduledEventFilter(queryInstrumentId, startsAt, view)
   );
   const [selectedProposalBooking, setSelectedProposalBooking] = useState<{
-    proposalBookingId: string | null;
-    scheduledEventId: string | null;
+    proposalBookingId: number | null;
+    scheduledEventId: number | null;
   }>({ proposalBookingId: null, scheduledEventId: null });
   const [selectedEquipmentBooking, setSelectedEquipmentBooking] = useState<
-    string | null
+    number | null
   >(null);
   const [showTodoBox, setShowTodoBox] = useState<boolean>(true);
 
@@ -156,7 +158,7 @@ export default function Calendar() {
     proposalBookings,
     loading: loadingBookings,
     refresh: refreshBookings,
-  } = useInstrumentProposalBookings(queryInstrument);
+  } = useInstrumentProposalBookings(queryInstrumentId);
 
   const {
     scheduledEvents,
@@ -170,7 +172,7 @@ export default function Calendar() {
     selectedEquipment,
     setSelectedEquipments,
   } = useEquipmentScheduledEvents({
-    equipmentIds: queryEquipment,
+    equipmentIds: queryEquipmentNumbers,
     startsAt: filter.startsAt,
     endsAt: filter.endsAt,
   });
@@ -191,18 +193,19 @@ export default function Calendar() {
       selectedEquipment?.length !== queryEquipment?.length ||
       !selectedEquipment?.every((eq) => queryEquipment?.includes(eq.toString()))
     ) {
-      setSelectedEquipments(queryEquipment?.map((item) => parseInt(item)));
+      setSelectedEquipments(queryEquipmentNumbers);
     }
   }, [
     selectedEquipment,
     queryEquipment,
     setSelectedEquipments,
     setScheduledEvents,
+    queryEquipmentNumbers,
   ]);
 
   useEffect(() => {
-    setFilter(generateScheduledEventFilter(queryInstrument, startsAt, view));
-  }, [queryInstrument, startsAt, view]);
+    setFilter(generateScheduledEventFilter(queryInstrumentId, startsAt, view));
+  }, [queryInstrumentId, startsAt, view]);
 
   const eqEventsTransformed: GetScheduledEventsQuery['scheduledEvents'] =
     eqEvents
@@ -283,9 +286,7 @@ export default function Calendar() {
         );
 
         if (equipmentScheduledEvent && equipmentScheduledEvent.equipmentId) {
-          setSelectedEquipmentBooking(
-            equipmentScheduledEvent.equipmentId.toString()
-          );
+          setSelectedEquipmentBooking(equipmentScheduledEvent.equipmentId);
         }
         break;
       }
@@ -341,7 +342,7 @@ export default function Calendar() {
             {queryInstrument && (
               <ScheduledEventDialog
                 selectedEvent={selectedEvent}
-                selectedInstrumentId={queryInstrument}
+                selectedInstrumentId={queryInstrumentId}
                 isDialogOpen={selectedEvent !== null}
                 closeDialog={closeDialog}
               />

--- a/src/components/calendar/Event.tsx
+++ b/src/components/calendar/Event.tsx
@@ -17,7 +17,12 @@ export type BasicProposalBooking =
 
 export type CalendarScheduledEvent = Pick<
   ScheduledEvent,
-  'id' | 'bookingType' | 'description' | 'bookingType' | 'equipmentId'
+  | 'id'
+  | 'bookingType'
+  | 'description'
+  | 'bookingType'
+  | 'equipmentId'
+  | 'status'
 > & {
   start: Date;
   end: Date;
@@ -84,7 +89,7 @@ export function eventPropGetter(event: CalendarScheduledEvent): {
   className?: string;
   style?: CSSProperties;
 } {
-  const eventStyle = isClosedEvent(event.proposalBooking)
+  const eventStyle = isClosedEvent({ status: event.status })
     ? getClosedBookingStyle()
     : getBookingTypeStyle(event.bookingType);
 
@@ -92,7 +97,7 @@ export function eventPropGetter(event: CalendarScheduledEvent): {
     style: {
       borderRadius: 0,
       border: '1px solid #FFF',
-      opacity: isDraftEvent(event.proposalBooking) ? '0.6' : 'unset',
+      opacity: isDraftEvent({ status: event.status }) ? '0.6' : 'unset',
       ...eventStyle,
     },
   };
@@ -103,6 +108,7 @@ export default function Event({
     description,
     start,
     proposalBooking,
+    status,
     bookingType,
     instrument,
     scheduledBy,
@@ -112,7 +118,12 @@ export default function Event({
   const classes = useStyles();
   switch (bookingType) {
     case ScheduledEventBookingType.USER_OPERATIONS:
-      return <ProposalBookingInfo booking={proposalBooking} />;
+      return (
+        <ProposalBookingInfo
+          booking={proposalBooking}
+          scheduledEventStatus={status}
+        />
+      );
     case ScheduledEventBookingType.EQUIPMENT:
       return (
         <EquipmentBookingInfo
@@ -121,7 +132,7 @@ export default function Event({
           scheduledBy={
             `${scheduledBy?.firstname} ${scheduledBy?.lastname}` ?? 'NA'
           }
-          proposalBooking={proposalBooking}
+          proposalBooking={{ status }}
         />
       );
     default:

--- a/src/components/calendar/Toolbar.tsx
+++ b/src/components/calendar/Toolbar.tsx
@@ -108,7 +108,7 @@ export default function Toolbar({
       equipments
     ) {
       setSelectedEquipment(
-        equipments.filter((eq) => queryEquipment.includes(parseInt(eq.id)))
+        equipments.filter((eq) => queryEquipment.includes(eq.id))
       );
     }
   }, [equipments, queryEquipment, selectedEquipment]);

--- a/src/components/common/Table.tsx
+++ b/src/components/common/Table.tsx
@@ -198,7 +198,7 @@ const useToolbarStyles = makeStyles((theme: Theme) => ({
 export type TooltipAction = {
   tooltip: string;
   icon: JSX.Element;
-  onClick: (rowIds: string[]) => void;
+  onClick: (rowIds: number[]) => void;
   clearSelect?: boolean;
 };
 
@@ -271,10 +271,10 @@ export type TableProps<T extends Record<string, unknown>> = {
   tooltipActions?: TooltipAction[];
   rowActions?: RowActions<T>;
   renderRow: (row: T) => JSX.Element;
-  extractKey: (obj: T) => string;
-  onDelete?: (ids: string[]) => void;
+  extractKey: (obj: T) => number;
+  onDelete?: (ids: number[]) => void;
   onPageChange?: (page: number) => void;
-  onSelectionChange?: (selected: string[]) => void;
+  onSelectionChange?: (selected: number[]) => void;
   'data-cy'?: string;
 };
 
@@ -313,7 +313,7 @@ export default function Table<T extends { [k: string]: any }>({
   const [orderBy, setOrderBy] = useState<keyof T | null>(
     defaultOrderBy ?? null
   );
-  const [selected, setSelected] = useState<string[]>([]);
+  const [selected, setSelected] = useState<number[]>([]);
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState<number>(5);
 
@@ -342,9 +342,9 @@ export default function Table<T extends { [k: string]: any }>({
     onSelectionChange?.([]);
   };
 
-  const handleClick = (_: React.MouseEvent<unknown>, key: string) => {
+  const handleClick = (_: React.MouseEvent<unknown>, key: number) => {
     const selectedIndex = selected.indexOf(key);
-    let newSelected: string[] = [];
+    let newSelected: number[] = [];
 
     if (selectedIndex === -1) {
       newSelected = newSelected.concat(selected, key);
@@ -377,7 +377,7 @@ export default function Table<T extends { [k: string]: any }>({
     setPage(0);
   };
 
-  const isSelected = (key: string) => selected.indexOf(key) !== -1;
+  const isSelected = (key: number) => selected.indexOf(key) !== -1;
 
   const emptyRows =
     rowsPerPage - Math.min(rowsPerPage, rows.length - page * rowsPerPage);

--- a/src/components/equipment/CreateEditEquipment.tsx
+++ b/src/components/equipment/CreateEditEquipment.tsx
@@ -89,7 +89,7 @@ export default function CreateEditEquipment() {
   const [indefiniteMaintenance, setIndefiniteMaintenance] = useState('1');
 
   const api = useDataApi();
-  const { loading, equipment } = useEquipment(id ?? '0');
+  const { loading, equipment } = useEquipment(id ? parseInt(id) : 0);
 
   useEffect(() => {
     if (loading) {
@@ -194,7 +194,7 @@ export default function CreateEditEquipment() {
                   const {
                     updateEquipment: { error },
                   } = await api().updateEquipment({
-                    id,
+                    id: parseInt(id),
                     updateEquipmentInput: input,
                   });
 

--- a/src/components/equipment/CreateEditEquipment.tsx
+++ b/src/components/equipment/CreateEditEquipment.tsx
@@ -1,9 +1,6 @@
 import MomentUtils from '@date-io/moment';
 import { getTranslation, ResourceId } from '@esss-swap/duo-localisation';
-import {
-  TYPE_ERR_INVALID_DATE,
-  atOrLaterThanMsg,
-} from '@esss-swap/duo-validation/lib/util';
+import { equipmentValidationSchema } from '@esss-swap/duo-validation';
 import {
   Grid,
   FormControlLabel,
@@ -26,7 +23,6 @@ import moment, { Moment } from 'moment';
 import { useSnackbar } from 'notistack';
 import React, { useState, useEffect } from 'react';
 import { useParams, useHistory, generatePath } from 'react-router';
-import * as Yup from 'yup';
 
 import Loader from 'components/common/Loader';
 import { PATH_VIEW_EQUIPMENT } from 'components/paths';
@@ -37,49 +33,8 @@ import { ContentContainer, StyledPaper } from 'styles/StyledComponents';
 import {
   toTzLessDateTime,
   parseTzLessDateTime,
-  TZ_LESS_DATE_TIME_FORMAT,
   TZ_LESS_DATE_TIME_LOW_PREC_FORMAT,
 } from 'utils/date';
-
-export const equipmentValidationSchema = Yup.object().shape({
-  name: Yup.string().min(3).max(100).required(),
-
-  maintenanceStartsAt: Yup.date()
-    .nullable()
-    .typeError(TYPE_ERR_INVALID_DATE)
-    .notRequired(),
-
-  maintenanceEndsAt: Yup.date()
-    .nullable()
-    .typeError(TYPE_ERR_INVALID_DATE)
-    .when(
-      'maintenanceStartsAt',
-      (
-        maintenanceStartsAt: Date,
-        schema: Yup.DateSchema<Date | null | undefined>
-      ) => {
-        if (!maintenanceStartsAt) {
-          return schema;
-        }
-
-        const min = moment(maintenanceStartsAt).add(1, 'minute');
-
-        if (!min.isValid()) {
-          return schema;
-        }
-
-        return schema
-          .nullable()
-          .typeError(TYPE_ERR_INVALID_DATE)
-          .min(
-            min.toDate(),
-            atOrLaterThanMsg(min.format(TZ_LESS_DATE_TIME_FORMAT))
-          )
-          .notRequired();
-      }
-    )
-    .notRequired(),
-});
 
 export default function CreateEditEquipment() {
   const history = useHistory();

--- a/src/components/equipment/CreateEditEquipment.tsx
+++ b/src/components/equipment/CreateEditEquipment.tsx
@@ -44,7 +44,7 @@ export default function CreateEditEquipment() {
   const [indefiniteMaintenance, setIndefiniteMaintenance] = useState('1');
 
   const api = useDataApi();
-  const { loading, equipment } = useEquipment(id ? parseInt(id) : 0);
+  const { loading, equipment } = useEquipment(parseInt(id ?? '0'));
 
   useEffect(() => {
     if (loading) {

--- a/src/components/equipment/EquipmentBookingDialog.tsx
+++ b/src/components/equipment/EquipmentBookingDialog.tsx
@@ -17,7 +17,7 @@ const useStyles = makeStyles(() => ({
 }));
 
 type EquipmentBookingDialogProps = {
-  activeEquipmentBookingId: string;
+  activeEquipmentBookingId: number;
   isDialogOpen: boolean;
   closeDialog: (shouldRefresh?: boolean) => void;
 };

--- a/src/components/equipment/Equipments.tsx
+++ b/src/components/equipment/Equipments.tsx
@@ -13,7 +13,7 @@ import useEquipments from 'hooks/equipment/useEquipments';
 import { ContentContainer, StyledPaper } from 'styles/StyledComponents';
 
 export type EquipmentTableRow = {
-  id: string;
+  id: number;
   name: string;
 };
 

--- a/src/components/equipment/ViewEquipment.tsx
+++ b/src/components/equipment/ViewEquipment.tsx
@@ -46,7 +46,7 @@ import { ContentContainer, StyledPaper } from 'styles/StyledComponents';
 import { parseTzLessDateTime, toTzLessDateTime } from 'utils/date';
 
 type TableRow = {
-  id: string;
+  id: number;
   startsAt: Moment;
   endsAt: Moment;
 
@@ -112,24 +112,24 @@ const MaintenanceInfo = ({
 };
 
 type ViewEquipmentProps = {
-  equipmentId: string;
+  equipmentId: number;
 };
 
 export default function ViewEquipment({ equipmentId }: ViewEquipmentProps) {
   const { enqueueSnackbar } = useSnackbar();
   const { showConfirmation } = useContext(AppContext);
   const { id } = useParams<{ id?: string }>();
+  const finalEquipmentId = id ? parseInt(id) : equipmentId;
   const classes = useStyles();
-  const { loading: equipmentLoading, equipment } = useEquipment(
-    id || equipmentId
-  );
+  const { loading: equipmentLoading, equipment } =
+    useEquipment(finalEquipmentId);
   const [selectedUsers, setSelectedUsers] = useState<
     Pick<User, 'id' | 'firstname' | 'lastname'>[]
   >([]);
   const [showPeopleModal, setShowPeopleModal] = useState(false);
   const { loading: scheduledEventsLoading, scheduledEvents } =
     useEquipmentScheduledEvents({
-      equipmentIds: [id || equipmentId],
+      equipmentIds: [finalEquipmentId],
       startsAt: toTzLessDateTime(new Date()),
       endsAt: toTzLessDateTime(moment(new Date()).add(1, 'year')),
     });
@@ -174,7 +174,7 @@ export default function ViewEquipment({ equipmentId }: ViewEquipmentProps) {
     row: TableRow,
     status: 'accept' | 'reject'
   ) => {
-    const assignmentEquipmentId = id || equipmentId;
+    const assignmentEquipmentId = finalEquipmentId;
 
     if (!assignmentEquipmentId) {
       return;

--- a/src/components/equipment/ViewEquipment.tsx
+++ b/src/components/equipment/ViewEquipment.tsx
@@ -174,9 +174,7 @@ export default function ViewEquipment({ equipmentId }: ViewEquipmentProps) {
     row: TableRow,
     status: 'accept' | 'reject'
   ) => {
-    const assignmentEquipmentId = finalEquipmentId;
-
-    if (!assignmentEquipmentId) {
+    if (!finalEquipmentId) {
       return;
     }
 
@@ -197,7 +195,7 @@ export default function ViewEquipment({ equipmentId }: ViewEquipmentProps) {
         const { confirmEquipmentAssignment: success } =
           await api().confirmEquipmentAssignment({
             confirmEquipmentAssignmentInput: {
-              equipmentId: assignmentEquipmentId,
+              equipmentId: finalEquipmentId,
               scheduledEventId: row.id,
               newStatus,
             },

--- a/src/components/proposalBooking/ProposalBookingDialog.tsx
+++ b/src/components/proposalBooking/ProposalBookingDialog.tsx
@@ -117,7 +117,7 @@ const getActiveStepByStatus = (
 };
 
 type ProposalBookingDialogProps = {
-  activeProposalBookingId: string;
+  activeProposalBookingId: number;
   isDialogOpen: boolean;
   closeDialog: (shouldRefresh?: boolean) => void;
 };

--- a/src/components/proposalBooking/ProposalBookingInfo.tsx
+++ b/src/components/proposalBooking/ProposalBookingInfo.tsx
@@ -6,6 +6,7 @@ import {
   isDraftEvent,
   isClosedEvent,
 } from 'components/calendar/Event';
+import { ProposalBookingStatus } from 'generated/sdk';
 
 const useStyles = makeStyles(() => ({
   container: {
@@ -35,8 +36,12 @@ const useStyles = makeStyles(() => ({
 
 interface ProposalBookingInfoProps {
   booking?: BasicProposalBooking;
+  scheduledEventStatus: ProposalBookingStatus;
 }
-function ProposalBookingInfo({ booking }: ProposalBookingInfoProps) {
+function ProposalBookingInfo({
+  booking,
+  scheduledEventStatus,
+}: ProposalBookingInfoProps) {
   const classes = useStyles();
   const proposal = booking?.proposal;
 
@@ -50,8 +55,8 @@ function ProposalBookingInfo({ booking }: ProposalBookingInfoProps) {
       data-cy={`proposal-event-${proposal.title}-${proposal.proposalId}`}
     >
       <div className={classes.proposalId}>
-        {isDraftEvent(booking) ? '[Draft] - ' : ''}
-        {isClosedEvent(booking) ? '[Closed] - ' : ''}
+        {isDraftEvent({ status: scheduledEventStatus }) ? '[Draft] - ' : ''}
+        {isClosedEvent({ status: scheduledEventStatus }) ? '[Closed] - ' : ''}
         {proposal.proposalId}
       </div>
       <div className={classes.title}>{proposal.title}</div>

--- a/src/components/proposalBooking/TimeTable.tsx
+++ b/src/components/proposalBooking/TimeTable.tsx
@@ -27,7 +27,7 @@ import {
 } from 'utils/date';
 
 export type TimeTableRow = {
-  id: string;
+  id: number;
   startsAt: Moment;
   endsAt: Moment;
   newlyCreated?: boolean;
@@ -51,7 +51,7 @@ function InlineTimeEdit({
 }: {
   row: TimeTableRow;
   onDiscard: () => void;
-  onSave: (id: string, startsAt: Moment, endsAt: Moment) => void;
+  onSave: (id: number, startsAt: Moment, endsAt: Moment) => void;
 }) {
   const classes = useStyles();
 
@@ -150,7 +150,7 @@ export default function TimeTable<T extends TimeTableRow>({
   onEditModeToggled,
   ...props
 }: TimeTableProps<T>) {
-  const [editing, setEditing] = useState<string | false>(false);
+  const [editing, setEditing] = useState<number | false>(false);
 
   // when the original list of rows change reset the current edit
   useEffect(() => {
@@ -161,7 +161,7 @@ export default function TimeTable<T extends TimeTableRow>({
     onEditModeToggled?.(!!editing);
   }, [editing, onEditModeToggled]);
 
-  const handleOnSave = (id: string, startsAt: Moment, endsAt: Moment) => {
+  const handleOnSave = (id: number, startsAt: Moment, endsAt: Moment) => {
     setEditing(false);
     handleRowsChange?.((rows) =>
       rows.map((row) => {
@@ -178,12 +178,12 @@ export default function TimeTable<T extends TimeTableRow>({
     );
   };
 
-  const handleDelete = (ids: string[]) => {
+  const handleDelete = (ids: number[]) => {
     setEditing(false);
     handleRowsChange?.((rows) => rows.filter((row) => !ids.includes(row.id)));
   };
 
-  const handleEditing = (id: string | false) => () => {
+  const handleEditing = (id: number | false) => () => {
     setEditing(id);
   };
 

--- a/src/components/proposalBooking/bookingSteps/BookingEventStep.tsx
+++ b/src/components/proposalBooking/bookingSteps/BookingEventStep.tsx
@@ -152,7 +152,7 @@ export default function BookingEventStep({
     handleRowsChange((rows) => [
       ...rows,
       {
-        id: `t-${Date.now()}`,
+        id: Date.now(),
         newlyCreated: true,
         startsAt: startsAt,
         endsAt: endsAt,
@@ -172,11 +172,14 @@ export default function BookingEventStep({
       } = await api().bulkUpsertScheduledEvents({
         input: {
           proposalBookingId: proposalBooking.id,
-          scheduledEvents: rows.map(({ startsAt, endsAt, ...rest }) => ({
-            ...rest,
-            startsAt: toTzLessDateTime(startsAt),
-            endsAt: toTzLessDateTime(endsAt),
-          })),
+          scheduledEvents: rows.map(
+            ({ startsAt, endsAt, id, newlyCreated }) => ({
+              newlyCreated,
+              id: newlyCreated ? 0 : id,
+              startsAt: toTzLessDateTime(startsAt),
+              endsAt: toTzLessDateTime(endsAt),
+            })
+          ),
         },
       });
 

--- a/src/components/proposalBooking/bookingSteps/EquipmentBookingStep.tsx
+++ b/src/components/proposalBooking/bookingSteps/EquipmentBookingStep.tsx
@@ -123,8 +123,8 @@ export default function EquipmentBookingStep({
   };
 
   const handleDeleteAssignment = (
-    equipmentId: string,
-    scheduledEventId: string
+    equipmentId: number,
+    scheduledEventId: number
   ) => {
     showConfirmation({
       message: (

--- a/src/components/proposalBooking/bookingSteps/FinalizeStep.tsx
+++ b/src/components/proposalBooking/bookingSteps/FinalizeStep.tsx
@@ -85,7 +85,7 @@ export default function FinalizeStep({
     handleRowsChange((rows) => [
       ...rows,
       {
-        id: `t-${Date.now()}`,
+        id: Date.now(),
         newlyCreated: true,
         startsAt: moment().startOf('hour'),
         endsAt: moment().startOf('hour').add(1, 'hour'),
@@ -102,9 +102,11 @@ export default function FinalizeStep({
       } = await api().bulkUpsertLostTimes({
         input: {
           proposalBookingId: proposalBooking.id,
-          lostTimes: rows.map(({ startsAt, endsAt, ...rest }) => ({
-            ...rest,
+          lostTimes: rows.map(({ startsAt, endsAt, id, newlyCreated }) => ({
+            id: id,
+            newlyCreated: newlyCreated,
             startsAt: toTzLessDateTime(startsAt),
+            scheduledEventId: id,
             endsAt: toTzLessDateTime(endsAt),
           })),
         },

--- a/src/components/proposalBooking/bookingSteps/FinalizeStep.tsx
+++ b/src/components/proposalBooking/bookingSteps/FinalizeStep.tsx
@@ -103,10 +103,10 @@ export default function FinalizeStep({
         input: {
           proposalBookingId: proposalBooking.id,
           lostTimes: rows.map(({ startsAt, endsAt, id, newlyCreated }) => ({
-            id: id,
+            id: newlyCreated ? 0 : id,
             newlyCreated: newlyCreated,
             startsAt: toTzLessDateTime(startsAt),
-            scheduledEventId: id,
+            scheduledEventId: proposalBooking.scheduledEvents[0].id,
             endsAt: toTzLessDateTime(endsAt),
           })),
         },

--- a/src/components/proposalBooking/bookingSteps/equipmentBooking/SelectEquipmentDialog.tsx
+++ b/src/components/proposalBooking/bookingSteps/equipmentBooking/SelectEquipmentDialog.tsx
@@ -16,7 +16,7 @@ import useAvailableEquipments from 'hooks/equipment/useAvailableEquipments';
 import { DetailedProposalBooking } from 'hooks/proposalBooking/useProposalBooking';
 
 export type EquipmentTableRow = {
-  id: string;
+  id: number;
   name: string;
   autoAccept: boolean;
 };
@@ -43,9 +43,9 @@ export default function SelectEquipmentDialog({
   const { enqueueSnackbar } = useSnackbar();
   const api = useDataApi();
   const { equipments, loading } = useAvailableEquipments(scheduledEvent.id);
-  const [selectedEquipments, setSelectedEquipments] = useState<string[]>([]);
+  const [selectedEquipments, setSelectedEquipments] = useState<number[]>([]);
 
-  const handleAssign = async (ids: string[]) => {
+  const handleAssign = async (ids: number[]) => {
     const { assignToScheduledEvents: success } =
       await api().assignEquipmentToScheduledEvent({
         assignEquipmentsToScheduledEventInput: {

--- a/src/components/proposalBooking/bookingSteps/equipmentBooking/SelectTimeSlotsDialog.tsx
+++ b/src/components/proposalBooking/bookingSteps/equipmentBooking/SelectTimeSlotsDialog.tsx
@@ -7,6 +7,7 @@ import {
   Dialog,
 } from '@material-ui/core';
 import { Add as AddIcon } from '@material-ui/icons';
+import moment from 'moment';
 import React, { useState, useEffect } from 'react';
 
 import Loader from 'components/common/Loader';
@@ -17,6 +18,7 @@ import {
 } from 'components/proposalBooking/TimeTable';
 import { DetailedProposalBooking } from 'hooks/proposalBooking/useProposalBooking';
 import useProposalBookingScheduledEvents from 'hooks/scheduledEvent/useProposalBookingScheduledEvents';
+import { ScheduledEventWithEquipments } from 'hooks/scheduledEvent/useScheduledEventsWithEquipments';
 import { parseTzLessDateTime, toTzLessDateTime } from 'utils/date';
 
 import SelectEquipmentDialog from './SelectEquipmentDialog';
@@ -30,10 +32,12 @@ export type EquipmentTableRow = {
 export default function SelectTimeSlotsDialog({
   isDialogOpen,
   proposalBooking,
+  scheduledEvent,
   closeDialog,
 }: {
   isDialogOpen: boolean;
   proposalBooking: DetailedProposalBooking;
+  scheduledEvent?: ScheduledEventWithEquipments;
   closeDialog: () => void;
 }) {
   const { loading, scheduledEvents } = useProposalBookingScheduledEvents(
@@ -42,6 +46,20 @@ export default function SelectTimeSlotsDialog({
   const [rows, setRows] = useState<TimeTableRow[]>([]);
   const [selectedScheduledEvent, setSelectedScheduledEvent] =
     useState<TimeTableRow | null>(null);
+
+  useEffect(() => {
+    if (scheduledEvent) {
+      setSelectedScheduledEvent(
+        scheduledEvent
+          ? {
+              id: scheduledEvent.id,
+              startsAt: moment(scheduledEvent.startsAt),
+              endsAt: moment(scheduledEvent.endsAt),
+            }
+          : null
+      );
+    }
+  }, [scheduledEvent]);
 
   useEffect(() => {
     if (!loading) {
@@ -80,7 +98,7 @@ export default function SelectTimeSlotsDialog({
       {isDialogOpen && selectedScheduledEvent && (
         <SelectEquipmentDialog
           isDialogOpen={true}
-          closeDialog={handleCloseDialog}
+          closeDialog={() => handleCloseDialog(!!scheduledEvent)}
           proposalBooking={proposalBooking}
           scheduledEvent={selectedScheduledEvent}
         />

--- a/src/components/proposalBooking/bookingSteps/equipmentBooking/TimeSlotEquipmentTable.tsx
+++ b/src/components/proposalBooking/bookingSteps/equipmentBooking/TimeSlotEquipmentTable.tsx
@@ -39,7 +39,7 @@ function Row({
 }: {
   row: ScheduledEventWithEquipments;
   readOnly?: boolean;
-  onDeleteAssignment: (equipmentId: string, scheduledEventId: string) => void;
+  onDeleteAssignment: (equipmentId: number, scheduledEventId: number) => void;
 }) {
   const [open, setOpen] = useState(false);
   const classes = useRowStyles();
@@ -122,7 +122,7 @@ export default function TimeSlotEquipmentTable({
 }: {
   rows: ScheduledEventWithEquipments[];
   readOnly?: boolean;
-  onDeleteAssignment: (equipmentId: string, scheduledEventId: string) => void;
+  onDeleteAssignment: (equipmentId: number, scheduledEventId: number) => void;
 }) {
   return (
     <TableContainer component={Paper}>

--- a/src/components/requests/ViewRequests.tsx
+++ b/src/components/requests/ViewRequests.tsx
@@ -14,7 +14,7 @@ import { ContentContainer, StyledPaper } from 'styles/StyledComponents';
 import { parseTzLessDateTime, toTzLessDateTime } from 'utils/date';
 
 type TableRow = {
-  id: string;
+  id: number;
   equipmentName: string;
   instrumentName?: string;
   proposalTitle?: string;
@@ -119,7 +119,7 @@ export default function ViewRequests() {
         const { confirmEquipmentAssignment: success } =
           await api().confirmEquipmentAssignment({
             confirmEquipmentAssignmentInput: {
-              equipmentId: row.equipmentId.toString(),
+              equipmentId: row.equipmentId,
               scheduledEventId: row.id,
               newStatus,
             },
@@ -188,7 +188,11 @@ export default function ViewRequests() {
                 rowActions={RowActions}
                 showEmptyRows
                 rows={rows}
-                extractKey={(el) => `${el.id}_${el.equipmentId}`}
+                extractKey={(el) => {
+                  const key = parseInt(`${el.id}${el.equipmentId}`);
+
+                  return key;
+                }}
                 renderRow={(row) => {
                   return (
                     <>

--- a/src/components/scheduledEvent/ScheduledEventDialog.tsx
+++ b/src/components/scheduledEvent/ScheduledEventDialog.tsx
@@ -41,7 +41,7 @@ type ScheduledEventDialogProps = {
     | SlotInfo
     | null;
   isDialogOpen: boolean;
-  selectedInstrumentId: string;
+  selectedInstrumentId: number;
   closeDialog: (shouldRefresh?: boolean) => void;
 };
 

--- a/src/components/timeSlotBooking/TimeSlotBookingDialog.tsx
+++ b/src/components/timeSlotBooking/TimeSlotBookingDialog.tsx
@@ -7,7 +7,13 @@ import {
   Stepper,
   StepButton,
 } from '@material-ui/core';
-import React, { useContext, useEffect, useState } from 'react';
+import React, {
+  Dispatch,
+  SetStateAction,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
 
 import Loader from 'components/common/Loader';
 import { AppContext } from 'context/AppContext';
@@ -57,6 +63,9 @@ export type ProposalBookingDialogStepProps = {
   activeStep: number;
   activeStatus: ProposalBookingStatus | null;
   scheduledEvent: ScheduledEventWithEquipments;
+  setScheduledEvent: Dispatch<
+    SetStateAction<ScheduledEventWithEquipments | null>
+  >;
   isDirty: boolean;
   handleNext: () => void;
   handleBack: () => void;
@@ -120,10 +129,11 @@ export default function ProposalBookingDialog({
     useState<ProposalBookingStatus | null>(null);
   const [isDirty, setIsDirty] = useState(false);
 
-  const { loading, scheduledEvent } = useScheduledEventWithEquipment({
-    proposalBookingId: activeProposalBookingId,
-    scheduledEventId: activeTimeSlotScheduledEventId,
-  });
+  const { loading, scheduledEvent, setScheduledEvent } =
+    useScheduledEventWithEquipment({
+      proposalBookingId: activeProposalBookingId,
+      scheduledEventId: activeTimeSlotScheduledEventId,
+    });
 
   useEffect(() => {
     if (!loading && scheduledEvent) {
@@ -223,6 +233,7 @@ export default function ProposalBookingDialog({
           activeStep,
           activeStatus,
           scheduledEvent,
+          setScheduledEvent,
           isDirty,
           handleNext,
           handleBack,

--- a/src/components/timeSlotBooking/TimeSlotBookingDialog.tsx
+++ b/src/components/timeSlotBooking/TimeSlotBookingDialog.tsx
@@ -7,13 +7,7 @@ import {
   Stepper,
   StepButton,
 } from '@material-ui/core';
-import React, {
-  Dispatch,
-  SetStateAction,
-  useContext,
-  useEffect,
-  useState,
-} from 'react';
+import React, { Dispatch, useContext, useEffect, useState } from 'react';
 
 import Loader from 'components/common/Loader';
 import { AppContext } from 'context/AppContext';
@@ -64,9 +58,8 @@ export type ProposalBookingDialogStepProps = {
   activeStatus: ProposalBookingStatus | null;
   scheduledEvent: ScheduledEventWithEquipments;
   setScheduledEvent: Dispatch<
-    SetStateAction<ScheduledEventWithEquipments | null>
+    React.SetStateAction<ScheduledEventWithEquipments | null>
   >;
-  refreshScheduledEvent: () => void;
   isDirty: boolean;
   handleNext: () => void;
   handleBack: () => void;
@@ -130,15 +123,11 @@ export default function ProposalBookingDialog({
     useState<ProposalBookingStatus | null>(null);
   const [isDirty, setIsDirty] = useState(false);
 
-  const {
-    loading,
-    scheduledEvent,
-    setScheduledEvent,
-    refresh: refreshScheduledEvent,
-  } = useScheduledEventWithEquipment({
-    proposalBookingId: activeProposalBookingId,
-    scheduledEventId: activeTimeSlotScheduledEventId,
-  });
+  const { loading, scheduledEvent, setScheduledEvent } =
+    useScheduledEventWithEquipment({
+      proposalBookingId: activeProposalBookingId,
+      scheduledEventId: activeTimeSlotScheduledEventId,
+    });
 
   useEffect(() => {
     if (!loading && scheduledEvent) {
@@ -215,7 +204,10 @@ export default function ProposalBookingDialog({
         className: classes.fullHeight,
       }}
     >
-      <DialogTitle>Time slot booking</DialogTitle>
+      <DialogTitle>
+        Time slot booking - (
+        {`${scheduledEvent?.startsAt} - ${scheduledEvent?.endsAt}`})
+      </DialogTitle>
       <Stepper nonLinear activeStep={activeStep}>
         {steps.map((label, index) => (
           <Step key={label}>
@@ -239,7 +231,6 @@ export default function ProposalBookingDialog({
           activeStatus,
           scheduledEvent,
           setScheduledEvent,
-          refreshScheduledEvent,
           isDirty,
           handleNext,
           handleBack,

--- a/src/components/timeSlotBooking/TimeSlotBookingDialog.tsx
+++ b/src/components/timeSlotBooking/TimeSlotBookingDialog.tsx
@@ -100,8 +100,8 @@ const getActiveStepByStatus = (
 };
 
 type ProposalBookingDialogProps = {
-  activeProposalBookingId: string;
-  activeTimeSlotScheduledEventId: string;
+  activeProposalBookingId: number;
+  activeTimeSlotScheduledEventId: number;
   isDialogOpen: boolean;
   closeDialog: (shouldRefresh?: boolean) => void;
 };
@@ -127,9 +127,8 @@ export default function ProposalBookingDialog({
 
   useEffect(() => {
     if (!loading && scheduledEvent) {
-      // TODO: Get status from scheduled event not from proposal booking globally when it is moved.
-      setActiveStep(0);
-      setActiveStatus(ProposalBookingStatus.DRAFT);
+      setActiveStep(getActiveStepByStatus(scheduledEvent.status));
+      setActiveStatus(scheduledEvent.status);
     }
   }, [loading, scheduledEvent]);
 

--- a/src/components/timeSlotBooking/TimeSlotBookingDialog.tsx
+++ b/src/components/timeSlotBooking/TimeSlotBookingDialog.tsx
@@ -1,0 +1,237 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  makeStyles,
+  Step,
+  Stepper,
+  StepButton,
+} from '@material-ui/core';
+import React, { useContext, useEffect, useState } from 'react';
+
+import Loader from 'components/common/Loader';
+import { AppContext } from 'context/AppContext';
+import { ProposalBookingStatus } from 'generated/sdk';
+import useScheduledEventWithEquipment, {
+  ScheduledEventWithEquipments,
+} from 'hooks/scheduledEvent/useScheduledEventWithEquipment';
+
+import TimeSlotBookingEventStep from './timeSlotBookingSteps/TimeSlotBookingEventStep';
+import TimeSlotClosedStep from './timeSlotBookingSteps/TimeSlotClosedStep';
+import TimeSlotEquipmentBookingStep from './timeSlotBookingSteps/TimeSlotEquipmentBookingStep';
+import TimeSlotFinalizeStep from './timeSlotBookingSteps/TimeSlotFinalizeStep';
+
+const useStyles = makeStyles(() => ({
+  fullHeight: {
+    height: '100%',
+  },
+}));
+
+export enum ProposalBookingSteps {
+  BOOK_EVENTS = 0,
+  BOOK_EQUIPMENT,
+  FINALIZE,
+
+  CLOSED,
+}
+
+const ProposalBookingStepNameMap: Record<
+  keyof typeof ProposalBookingSteps,
+  string
+> = {
+  BOOK_EVENTS: 'Scheduled event details',
+  BOOK_EQUIPMENT: 'Equipment booking',
+  FINALIZE: 'Finalize',
+  CLOSED: 'Closed',
+};
+
+const steps = [
+  ProposalBookingStepNameMap.BOOK_EVENTS,
+  ProposalBookingStepNameMap.BOOK_EQUIPMENT,
+  ProposalBookingStepNameMap.FINALIZE,
+  ProposalBookingStepNameMap.CLOSED,
+];
+const maxSteps = steps.length;
+
+export type ProposalBookingDialogStepProps = {
+  activeStep: number;
+  activeStatus: ProposalBookingStatus | null;
+  scheduledEvent: ScheduledEventWithEquipments;
+  isDirty: boolean;
+  handleNext: () => void;
+  handleBack: () => void;
+  handleResetSteps: () => void;
+  handleSetDirty: (isDirty: boolean) => void;
+  handleCloseDialog: () => void;
+  handleSetActiveStepByStatus: (status: ProposalBookingStatus) => void;
+};
+
+function getActiveStep(props: ProposalBookingDialogStepProps) {
+  switch (props.activeStep) {
+    case ProposalBookingSteps.BOOK_EVENTS:
+      return <TimeSlotBookingEventStep {...props} />;
+    case ProposalBookingSteps.BOOK_EQUIPMENT:
+      return <TimeSlotEquipmentBookingStep {...props} />;
+    case ProposalBookingSteps.FINALIZE:
+      return <TimeSlotFinalizeStep {...props} />;
+
+    case ProposalBookingSteps.CLOSED:
+      return <TimeSlotClosedStep {...props} />;
+
+    default:
+      return <DialogContent>Unknown step</DialogContent>;
+  }
+}
+
+const getActiveStepByStatus = (
+  status: ProposalBookingStatus | null
+): number => {
+  switch (status) {
+    case ProposalBookingStatus.DRAFT:
+      return ProposalBookingSteps.BOOK_EVENTS;
+    case ProposalBookingStatus.BOOKED:
+      return ProposalBookingSteps.FINALIZE;
+    case ProposalBookingStatus.CLOSED:
+      return ProposalBookingSteps.CLOSED;
+
+    default:
+      return -1;
+  }
+};
+
+type ProposalBookingDialogProps = {
+  activeProposalBookingId: string;
+  activeTimeSlotScheduledEventId: string;
+  isDialogOpen: boolean;
+  closeDialog: (shouldRefresh?: boolean) => void;
+};
+
+export default function ProposalBookingDialog({
+  activeProposalBookingId,
+  activeTimeSlotScheduledEventId,
+  isDialogOpen,
+  closeDialog,
+}: ProposalBookingDialogProps) {
+  const classes = useStyles();
+
+  const { showConfirmation } = useContext(AppContext);
+  const [activeStep, setActiveStep] = useState(-1);
+  const [activeStatus, setActiveStatus] =
+    useState<ProposalBookingStatus | null>(null);
+  const [isDirty, setIsDirty] = useState(false);
+
+  const { loading, scheduledEvent } = useScheduledEventWithEquipment({
+    proposalBookingId: activeProposalBookingId,
+    scheduledEventId: activeTimeSlotScheduledEventId,
+  });
+
+  useEffect(() => {
+    if (!loading && scheduledEvent) {
+      // TODO: Get status from scheduled event not from proposal booking globally when it is moved.
+      setActiveStep(0);
+      setActiveStatus(ProposalBookingStatus.DRAFT);
+    }
+  }, [loading, scheduledEvent]);
+
+  const handleResetSteps = () => {
+    setActiveStep(ProposalBookingSteps.BOOK_EVENTS);
+    setIsDirty(false);
+  };
+
+  const handleNext = () => {
+    setActiveStep((prevStep) => Math.min(prevStep + 1, maxSteps));
+    setIsDirty(false);
+  };
+
+  const handleBack = () => {
+    setActiveStep((prevStep) => Math.max(prevStep - 1, 0));
+    setIsDirty(false);
+  };
+
+  const handleSetStep = (step: number) => () => {
+    setActiveStep(step);
+    setIsDirty(false);
+  };
+
+  const handleSetActiveStepByStatus = (status: ProposalBookingStatus) => {
+    setActiveStatus(status);
+  };
+
+  const handleCloseDialog = () => {
+    isDirty
+      ? showConfirmation({
+          message: (
+            <>
+              You have <strong>unsaved work</strong>, are you sure you want to
+              continue?
+            </>
+          ),
+          cb: () => closeDialog(true),
+        })
+      : closeDialog(true);
+  };
+
+  const handleSetDirty = (isDirty: boolean) => {
+    setIsDirty(isDirty);
+  };
+
+  if (loading) {
+    return (
+      <Dialog
+        open={isDialogOpen}
+        onClose={handleCloseDialog}
+        fullWidth
+        maxWidth="lg"
+        PaperProps={{
+          className: classes.fullHeight,
+        }}
+      >
+        <Loader />
+      </Dialog>
+    );
+  }
+
+  return (
+    <Dialog
+      open={isDialogOpen}
+      onClose={handleCloseDialog}
+      fullWidth
+      maxWidth="lg"
+      PaperProps={{
+        className: classes.fullHeight,
+      }}
+    >
+      <DialogTitle>Time slot booking</DialogTitle>
+      <Stepper nonLinear activeStep={activeStep}>
+        {steps.map((label, index) => (
+          <Step key={label}>
+            <StepButton
+              data-cy={`time-slot-booking-step-${ProposalBookingSteps[index]}`}
+              onClick={handleSetStep(index)}
+              completed={
+                index <=
+                Math.max(getActiveStepByStatus(activeStatus), activeStep)
+              }
+              disabled={index > getActiveStepByStatus(activeStatus)}
+            >
+              {label}
+            </StepButton>
+          </Step>
+        ))}
+      </Stepper>
+      {scheduledEvent &&
+        getActiveStep({
+          activeStep,
+          activeStatus,
+          scheduledEvent,
+          isDirty,
+          handleNext,
+          handleBack,
+          handleSetDirty,
+          handleResetSteps,
+          handleSetActiveStepByStatus,
+          handleCloseDialog,
+        })}
+    </Dialog>
+  );
+}

--- a/src/components/timeSlotBooking/TimeSlotBookingDialog.tsx
+++ b/src/components/timeSlotBooking/TimeSlotBookingDialog.tsx
@@ -66,6 +66,7 @@ export type ProposalBookingDialogStepProps = {
   setScheduledEvent: Dispatch<
     SetStateAction<ScheduledEventWithEquipments | null>
   >;
+  refreshScheduledEvent: () => void;
   isDirty: boolean;
   handleNext: () => void;
   handleBack: () => void;
@@ -129,11 +130,15 @@ export default function ProposalBookingDialog({
     useState<ProposalBookingStatus | null>(null);
   const [isDirty, setIsDirty] = useState(false);
 
-  const { loading, scheduledEvent, setScheduledEvent } =
-    useScheduledEventWithEquipment({
-      proposalBookingId: activeProposalBookingId,
-      scheduledEventId: activeTimeSlotScheduledEventId,
-    });
+  const {
+    loading,
+    scheduledEvent,
+    setScheduledEvent,
+    refresh: refreshScheduledEvent,
+  } = useScheduledEventWithEquipment({
+    proposalBookingId: activeProposalBookingId,
+    scheduledEventId: activeTimeSlotScheduledEventId,
+  });
 
   useEffect(() => {
     if (!loading && scheduledEvent) {
@@ -234,6 +239,7 @@ export default function ProposalBookingDialog({
           activeStatus,
           scheduledEvent,
           setScheduledEvent,
+          refreshScheduledEvent,
           isDirty,
           handleNext,
           handleBack,

--- a/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotBookingEventStep.tsx
+++ b/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotBookingEventStep.tsx
@@ -144,7 +144,6 @@ export default function TimeSlotBookingEventStep({
   }, [proposalBooking]);
 
   const handleSubmit = async () => {
-    // TODO: Add updateScheduledEvent method on the backend and uncomment this.
     try {
       setIsLoading(true);
       if (!startsAt || !endsAt) {

--- a/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotBookingEventStep.tsx
+++ b/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotBookingEventStep.tsx
@@ -1,0 +1,379 @@
+import {
+  Avatar,
+  Button,
+  DialogActions,
+  DialogContent,
+  Divider,
+  Grid,
+  List,
+  ListItem,
+  ListItemAvatar,
+  ListItemText,
+  makeStyles,
+} from '@material-ui/core';
+import {
+  CalendarToday as CalendarTodayIcon,
+  HourglassEmpty as HourglassEmptyIcon,
+  Save as SaveIcon,
+} from '@material-ui/icons';
+import humanizeDuration from 'humanize-duration';
+import React, { useContext, useState } from 'react';
+
+import Loader from 'components/common/Loader';
+import { AppContext } from 'context/AppContext';
+import { ProposalBookingStatus } from 'generated/sdk';
+import { useDataApi } from 'hooks/common/useDataApi';
+// import useProposalBookingScheduledEvents from 'hooks/scheduledEvent/useProposalBookingScheduledEvents';
+import { toTzLessDateTime } from 'utils/date';
+
+import { ProposalBookingDialogStepProps } from '../TimeSlotBookingDialog';
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    flexShrink: 0,
+    flexGrow: 0,
+  },
+  list: {
+    width: '100%',
+    backgroundColor: theme.palette.background.paper,
+  },
+  divider: {
+    marginLeft: theme.spacing(6),
+  },
+  allocatablePositive: {
+    color: theme.palette.success.main,
+  },
+  allocatableNegative: {
+    color: theme.palette.error.main,
+  },
+  flexColumn: {
+    flexGrow: 1,
+    maxWidth: '100%',
+    flexBasis: 0,
+    alignSelf: 'flex-start',
+  },
+  spacingLeft: {
+    marginLeft: theme.spacing(2),
+  },
+}));
+
+const formatDuration = (durSec: number) =>
+  humanizeDuration(durSec * 1000, {
+    conjunction: ' and ',
+    serialComma: false,
+    largest: 3,
+  });
+
+export default function BookingEventStep({
+  activeStatus,
+  scheduledEvent,
+
+  isDirty,
+  handleNext,
+  handleSetDirty,
+  handleCloseDialog,
+}: ProposalBookingDialogStepProps) {
+  const [isEditingTimeTable, setIsEditingTimeTable] = useState(false);
+
+  const isStepReadOnly =
+    activeStatus !== ProposalBookingStatus.DRAFT || isEditingTimeTable;
+
+  // const {
+  //   call: { startCycle, endCycle, cycleComment },
+  //   proposal: { title },
+  // } = proposalBooking;
+
+  const classes = useStyles();
+
+  // const { loading, scheduledEvents } = useProposalBookingScheduledEvents(
+  //   proposalBooking.id
+  // );
+
+  const { showConfirmation } = useContext(AppContext);
+  // const { enqueueSnackbar } = useSnackbar();
+  const api = useDataApi();
+  // const [rows, setRows] = useState<TimeTableRow[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  // const { allocated, allocatable } = useMemo(() => {
+  //   const allocated = rows.reduce(
+  //     (total, curr) => total + curr.endsAt.diff(curr.startsAt, 'seconds'),
+  //     0
+  //   );
+
+  //   return {
+  //     allocated,
+  //     allocatable: proposalBooking.allocatedTime - allocated,
+  //   };
+  // }, [rows, proposalBooking]);
+
+  // const handleOnEditModeChanged = useCallback((isReadOnly: boolean) => {
+  //   setIsEditingTimeTable(isReadOnly);
+  // }, []);
+
+  // useEffect(() => {
+  //   if (!loading) {
+  //     setRows(
+  //       scheduledEvents.map(({ startsAt, endsAt, ...rest }) => ({
+  //         ...rest,
+  //         startsAt: parseTzLessDateTime(startsAt),
+  //         endsAt: parseTzLessDateTime(endsAt),
+  //       }))
+  //     );
+
+  //     setIsLoading(false);
+  //   }
+  // }, [loading, scheduledEvents]);
+
+  // const handleRowsChange = (cb: React.SetStateAction<TimeTableRow[]>) => {
+  //   !isDirty && handleSetDirty(true);
+  //   setRows(cb);
+  // };
+
+  // const handleAdd = () => {
+  //   const lastRow = rows.length > 0 ? rows[rows.length - 1] : undefined;
+  //   const startsAt = lastRow?.endsAt ?? moment().startOf('hour');
+  //   const endsAt = startsAt.clone().startOf('hour').add(1, 'day');
+
+  //   handleRowsChange((rows) => [
+  //     ...rows,
+  //     {
+  //       id: `t-${Date.now()}`,
+  //       newlyCreated: true,
+  //       startsAt: startsAt,
+  //       endsAt: endsAt,
+  //     },
+  //   ]);
+  // };
+
+  // const handleSubmit = async () => {
+  //   try {
+  //     setIsLoading(true);
+
+  //     const {
+  //       bulkUpsertScheduledEvents: {
+  //         error,
+  //         scheduledEvent: updatedScheduledEvents,
+  //       },
+  //     } = await api().bulkUpsertScheduledEvents({
+  //       input: {
+  //         proposalBookingId: proposalBooking.id,
+  //         scheduledEvents: rows.map(({ startsAt, endsAt, ...rest }) => ({
+  //           ...rest,
+  //           startsAt: toTzLessDateTime(startsAt),
+  //           endsAt: toTzLessDateTime(endsAt),
+  //         })),
+  //       },
+  //     });
+
+  //     if (error) {
+  //       enqueueSnackbar(getTranslation(error as ResourceId), {
+  //         variant: 'error',
+  //       });
+  //     } else {
+  //       updatedScheduledEvents &&
+  //         setRows(
+  //           updatedScheduledEvents.map(({ startsAt, endsAt, ...rest }) => ({
+  //             ...rest,
+  //             startsAt: parseTzLessDateTime(startsAt),
+  //             endsAt: parseTzLessDateTime(endsAt),
+  //           }))
+  //         );
+  //     }
+
+  //     handleSetDirty(false);
+  //   } catch (e) {
+  //     // TODO
+  //     console.error(e);
+  //   } finally {
+  //     setIsLoading(false);
+  //   }
+  // };
+
+  const handleSaveDraft = () => {
+    // hasOverlappingEvents(rows)
+    //   ? showConfirmation({
+    //       message: (
+    //         <>
+    //           You have <strong>overlapping bookings</strong>, are you sure you
+    //           want to continue?
+    //         </>
+    //       ),
+    //       cb: handleSubmit,
+    //     })
+    //   : handleSubmit();
+  };
+
+  // const saveAndContinue = async () => {
+  //   await handleSubmit();
+  //   handleNext();
+  // };
+
+  const handleSaveAndContinue = async () => {
+    // hasOverlappingEvents(rows)
+    //   ? showConfirmation({
+    //       message: (
+    //         <>
+    //           You have <strong>overlapping bookings</strong>, are you sure you
+    //           want to continue?
+    //         </>
+    //       ),
+    //       cb: saveAndContinue,
+    //     })
+    //   : saveAndContinue();
+    // await handleSubmit();
+    handleNext();
+  };
+
+  return (
+    <>
+      {isLoading && <Loader />}
+
+      <DialogContent className={classes.root}>
+        <Grid container spacing={2}>
+          <Grid item xs={6}>
+            <List className={classes.list} dense>
+              <ListItem disableGutters>
+                <ListItemAvatar>
+                  <Avatar>
+                    <CalendarTodayIcon />
+                  </Avatar>
+                </ListItemAvatar>
+                <ListItemText
+                  primary="Starts at"
+                  secondary={toTzLessDateTime(scheduledEvent.startsAt)}
+                />
+              </ListItem>
+              <Divider
+                variant="inset"
+                component="li"
+                className={classes.divider}
+              />
+              {/* <ListItem disableGutters>
+                <ListItemAvatar>
+                  <Avatar>
+                    <CalendarTodayIcon />
+                  </Avatar>
+                </ListItemAvatar>
+                <ListItemText
+                  primary="Cycle starts"
+                  secondary={toTzLessDateTime()}
+                />
+                <ListItemText
+                  primary="Cycle ends"
+                  secondary={toTzLessDateTime(endCycle)}
+                />
+              </ListItem> */}
+            </List>
+          </Grid>
+          <Grid item xs={6}>
+            <List className={classes.list} dense>
+              <ListItem disableGutters>
+                <ListItemAvatar>
+                  <Avatar>
+                    <HourglassEmptyIcon />
+                  </Avatar>
+                </ListItemAvatar>
+                <ListItemText
+                  primary="Ends at"
+                  secondary={toTzLessDateTime(scheduledEvent.endsAt)}
+                />
+              </ListItem>
+              <Divider
+                variant="inset"
+                component="li"
+                className={classes.divider}
+              />
+              {/* <ListItem disableGutters>
+                <ListItemAvatar>
+                  <Avatar>
+                    <HourglassEmptyIcon />
+                  </Avatar>
+                </ListItemAvatar>
+                <ListItemText
+                  primary="Allocated time"
+                  secondary={formatDuration(allocated)}
+                  className={classes.flexColumn}
+                />
+                <ListItemText
+                  primary="Allocatable time"
+                  className={classes.flexColumn}
+                  secondary={
+                    <>
+                      <span
+                        className={clsx({
+                          [classes.allocatablePositive]: allocatable > 0,
+                          [classes.allocatableNegative]: allocatable < 0,
+                        })}
+                      >
+                        {allocatable < 0
+                          ? `0 seconds (+${formatDuration(allocatable)})`
+                          : formatDuration(allocatable)}
+                      </span>
+                    </>
+                  }
+                />
+              </ListItem> */}
+            </List>
+          </Grid>
+        </Grid>
+      </DialogContent>
+
+      <DialogContent>
+        {/* <TimeTable
+          selectable={!isStepReadOnly}
+          editable={!isStepReadOnly}
+          maxHeight={380}
+          rows={rows}
+          handleRowsChange={handleRowsChange}
+          onEditModeToggled={handleOnEditModeChanged}
+          titleComponent={
+            <>
+              Time slots
+              <Button
+                variant="contained"
+                color="primary"
+                startIcon={<AddIcon />}
+                className={classes.spacingLeft}
+                onClick={handleAdd}
+                data-cy="btn-add-time-slot"
+                disabled={isStepReadOnly}
+              >
+                Add
+              </Button>
+            </>
+          }
+        /> */}
+      </DialogContent>
+
+      <DialogActions>
+        <Button
+          color="primary"
+          onClick={handleCloseDialog}
+          data-cy="btn-close-dialog"
+        >
+          Close
+        </Button>
+        <Button
+          variant="contained"
+          color="primary"
+          startIcon={<SaveIcon />}
+          onClick={handleSaveDraft}
+          data-cy="btn-save"
+          disabled={isStepReadOnly}
+        >
+          Save draft
+        </Button>
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={handleSaveAndContinue}
+          data-cy="btn-next"
+          disabled={isStepReadOnly}
+        >
+          Save and continue
+        </Button>
+      </DialogActions>
+    </>
+  );
+}

--- a/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotBookingEventStep.tsx
+++ b/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotBookingEventStep.tsx
@@ -35,7 +35,7 @@ import React, { useContext, useMemo, useState } from 'react';
 
 import Loader from 'components/common/Loader';
 import { AppContext } from 'context/AppContext';
-import { ProposalBookingStatus } from 'generated/sdk';
+import { ProposalBooking, ProposalBookingStatus } from 'generated/sdk';
 import { useDataApi } from 'hooks/common/useDataApi';
 import {
   toTzLessDateTime,
@@ -80,7 +80,7 @@ const formatDuration = (durSec: number) =>
     largest: 3,
   });
 
-export default function BookingEventStep({
+export default function TimeSlotBookingEventStep({
   activeStatus,
   scheduledEvent,
   setScheduledEvent,
@@ -89,12 +89,11 @@ export default function BookingEventStep({
   handleSetDirty,
   handleCloseDialog,
 }: ProposalBookingDialogStepProps) {
-  const [isEditingTimeTable, setIsEditingTimeTable] = useState(false);
+  const proposalBooking = scheduledEvent.proposalBooking as ProposalBooking;
   const [editingStartDate, setEditingStartDate] = useState(false);
   const [editingEndDate, setEditingEndDate] = useState(false);
 
-  const isStepReadOnly =
-    activeStatus !== ProposalBookingStatus.DRAFT || isEditingTimeTable;
+  const isStepReadOnly = activeStatus !== ProposalBookingStatus.DRAFT;
 
   const classes = useStyles();
 
@@ -132,7 +131,7 @@ export default function BookingEventStep({
   };
 
   const { allocated, allocatable } = useMemo(() => {
-    const allocated = scheduledEvent.proposalBooking!.scheduledEvents.reduce(
+    const allocated = proposalBooking.scheduledEvents.reduce(
       (total, curr) =>
         total + moment(curr.endsAt).diff(curr.startsAt, 'seconds'),
       0
@@ -140,9 +139,9 @@ export default function BookingEventStep({
 
     return {
       allocated,
-      allocatable: scheduledEvent.proposalBooking!.allocatedTime - allocated,
+      allocatable: proposalBooking.allocatedTime - allocated,
     };
-  }, [scheduledEvent.proposalBooking]);
+  }, [proposalBooking]);
 
   const handleSubmit = async () => {
     // TODO: Add updateScheduledEvent method on the backend and uncomment this.
@@ -184,7 +183,7 @@ export default function BookingEventStep({
 
   const handleSaveDraft = () => {
     hasOverlappingEvents(
-      scheduledEvent.proposalBooking!.scheduledEvents.map((event) => ({
+      proposalBooking.scheduledEvents.map((event) => ({
         id: event.id,
         startsAt: moment(event.startsAt),
         endsAt: moment(event.endsAt),
@@ -209,7 +208,7 @@ export default function BookingEventStep({
 
   const handleSaveAndContinue = async () => {
     hasOverlappingEvents(
-      scheduledEvent.proposalBooking!.scheduledEvents.map((event) => ({
+      proposalBooking.scheduledEvents.map((event) => ({
         id: event.id,
         startsAt: moment(event.startsAt),
         endsAt: moment(event.endsAt),
@@ -246,7 +245,7 @@ export default function BookingEventStep({
                     <ListItemText
                       onClick={() => setEditingStartDate(true)}
                       primary="Starts at"
-                      secondary={toTzLessDateTime(startsAt!)}
+                      secondary={toTzLessDateTime(startsAt as Moment)}
                     />
                   )}
                   {editingStartDate && (
@@ -351,7 +350,7 @@ export default function BookingEventStep({
                     <ListItemText
                       primary="Ends at"
                       onClick={() => setEditingEndDate(true)}
-                      secondary={toTzLessDateTime(endsAt!)}
+                      secondary={toTzLessDateTime(endsAt as Moment)}
                     />
                   )}
                   {editingEndDate && (
@@ -403,8 +402,8 @@ export default function BookingEventStep({
                     </Avatar>
                   </ListItemAvatar>
                   <ListItemText
-                    primary="Proposal"
-                    secondary={scheduledEvent.proposalBooking?.proposal?.title}
+                    primary="Proposal title"
+                    secondary={proposalBooking.proposal?.title}
                   />
                 </ListItem>
                 <Divider

--- a/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotClosedStep.tsx
+++ b/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotClosedStep.tsx
@@ -8,6 +8,7 @@ import { Alert } from '@material-ui/lab';
 import React, { useEffect, useState } from 'react';
 
 import Loader from 'components/common/Loader';
+import { ProposalBooking } from 'generated/sdk';
 import useProposalBookingLostTimes from 'hooks/lostTime/useProposalBookingLostTimes';
 import { parseTzLessDateTime } from 'utils/date';
 
@@ -21,14 +22,15 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-export default function ClosedStep({
+export default function TimeSlotClosedStep({
   scheduledEvent,
   handleCloseDialog,
 }: ProposalBookingDialogStepProps) {
   const classes = useStyles();
+  const proposalBooking = scheduledEvent.proposalBooking as ProposalBooking;
 
   const { loading, lostTimes } = useProposalBookingLostTimes(
-    scheduledEvent.proposalBooking!.id,
+    proposalBooking.id,
     scheduledEvent.id
   );
 

--- a/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotClosedStep.tsx
+++ b/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotClosedStep.tsx
@@ -1,0 +1,76 @@
+import {
+  Button,
+  DialogActions,
+  DialogContent,
+  makeStyles,
+} from '@material-ui/core';
+import { Alert } from '@material-ui/lab';
+import React, { useEffect, useState } from 'react';
+
+import Loader from 'components/common/Loader';
+import useProposalBookingLostTimes from 'hooks/lostTime/useProposalBookingLostTimes';
+import { parseTzLessDateTime } from 'utils/date';
+
+import TimeTable, { TimeTableRow } from '../../proposalBooking/TimeTable';
+import { ProposalBookingDialogStepProps } from '../TimeSlotBookingDialog';
+
+const useStyles = makeStyles(() => ({
+  resetFlex: {
+    flexShrink: 0,
+    flexGrow: 0,
+  },
+}));
+
+export default function ClosedStep({
+  scheduledEvent,
+  handleCloseDialog,
+}: ProposalBookingDialogStepProps) {
+  const classes = useStyles();
+
+  // TODO: We should introduce new connection between scheduled event time slot and lost time. Now the connection is between proposal booking globally and lost times.
+  const { loading, lostTimes } = useProposalBookingLostTimes(scheduledEvent.id);
+
+  const [rows, setRows] = useState<TimeTableRow[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if (!loading) {
+      setRows(
+        lostTimes.map(({ startsAt, endsAt, ...rest }) => ({
+          ...rest,
+          startsAt: parseTzLessDateTime(startsAt),
+          endsAt: parseTzLessDateTime(endsAt),
+        }))
+      );
+
+      setIsLoading(false);
+    }
+  }, [loading, lostTimes]);
+
+  return (
+    <>
+      {isLoading && <Loader />}
+      <DialogContent className={classes.resetFlex}>
+        <Alert severity="info">
+          Proposal booking is already closed, you can not edit it.
+        </Alert>
+      </DialogContent>
+      <DialogContent>
+        <TimeTable
+          maxHeight={530}
+          rows={rows}
+          titleComponent="Logged lost time"
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button
+          color="primary"
+          onClick={handleCloseDialog}
+          data-cy="btn-close-dialog"
+        >
+          Close
+        </Button>
+      </DialogActions>
+    </>
+  );
+}

--- a/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotClosedStep.tsx
+++ b/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotClosedStep.tsx
@@ -27,8 +27,10 @@ export default function ClosedStep({
 }: ProposalBookingDialogStepProps) {
   const classes = useStyles();
 
-  // TODO: We should introduce new connection between scheduled event time slot and lost time. Now the connection is between proposal booking globally and lost times.
-  const { loading, lostTimes } = useProposalBookingLostTimes(scheduledEvent.id);
+  const { loading, lostTimes } = useProposalBookingLostTimes(
+    scheduledEvent.proposalBooking!.id,
+    scheduledEvent.id
+  );
 
   const [rows, setRows] = useState<TimeTableRow[]>([]);
   const [isLoading, setIsLoading] = useState(true);

--- a/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotEquipmentBookingStep.tsx
+++ b/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotEquipmentBookingStep.tsx
@@ -123,8 +123,8 @@ export default function EquipmentBookingStep({
   };
 
   const handleDeleteAssignment = (
-    equipmentId: string,
-    scheduledEventId: string
+    equipmentId: number,
+    scheduledEventId: number
   ) => {
     showConfirmation({
       message: (

--- a/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotEquipmentBookingStep.tsx
+++ b/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotEquipmentBookingStep.tsx
@@ -25,6 +25,7 @@ import SelectTimeSlotsDialog from 'components/proposalBooking/bookingSteps/equip
 import { AppContext } from 'context/AppContext';
 import {
   EquipmentAssignmentStatus,
+  ProposalBooking,
   ProposalBookingStatus,
 } from 'generated/sdk';
 import { useDataApi } from 'hooks/common/useDataApi';
@@ -58,7 +59,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export default function EquipmentBookingStep({
+export default function TimeSlotEquipmentBookingStep({
   activeStatus,
   scheduledEvent,
   handleNext,
@@ -66,6 +67,7 @@ export default function EquipmentBookingStep({
   handleSetActiveStepByStatus,
   handleCloseDialog,
 }: ProposalBookingDialogStepProps) {
+  const proposalBooking = scheduledEvent.proposalBooking as ProposalBooking;
   const isStepReadOnly = activeStatus !== ProposalBookingStatus.DRAFT;
 
   const classes = useStyles();
@@ -78,7 +80,7 @@ export default function EquipmentBookingStep({
     loading: loadingEquipments,
     refresh,
   } = useScheduledEventEquipments({
-    proposalBookingId: scheduledEvent.proposalBooking!.id,
+    proposalBookingId: proposalBooking.id,
     scheduledEventId: scheduledEvent.id,
   });
 
@@ -151,7 +153,7 @@ export default function EquipmentBookingStep({
             deleteEquipmentAssignmentInput: {
               equipmentId,
               scheduledEventId,
-              proposalBookingId: scheduledEvent.proposalBooking!.id,
+              proposalBookingId: proposalBooking.id,
             },
           });
 
@@ -177,9 +179,7 @@ export default function EquipmentBookingStep({
         <SelectTimeSlotsDialog
           isDialogOpen={equipmentDialog}
           scheduledEvent={scheduledEvent}
-          proposalBooking={
-            scheduledEvent.proposalBooking as DetailedProposalBooking
-          }
+          proposalBooking={proposalBooking as DetailedProposalBooking}
           closeDialog={handleEquipmentCloseDialog}
         />
       )}
@@ -249,18 +249,6 @@ export default function EquipmentBookingStep({
             </TableBody>
           </MuiTable>
         </Box>
-        {/* <TimeSlotEquipmentTable
-          rows={[
-            {
-              id: scheduledEvent.id,
-              startsAt: scheduledEvent.startsAt,
-              endsAt: scheduledEvent.endsAt,
-              equipments: scheduledEventEquipments,
-            },
-          ]}
-          onDeleteAssignment={handleDeleteAssignment}
-          readOnly={isStepReadOnly}
-        /> */}
         {!allEquipmentsAccepted && (
           <Alert
             severity="warning"

--- a/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotEquipmentBookingStep.tsx
+++ b/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotEquipmentBookingStep.tsx
@@ -1,0 +1,241 @@
+import { getTranslation, ResourceId } from '@esss-swap/duo-localisation';
+import {
+  DialogContent,
+  Typography,
+  DialogActions,
+  Button,
+  makeStyles,
+  Toolbar,
+} from '@material-ui/core';
+import { Add as AddIcon } from '@material-ui/icons';
+import Alert from '@material-ui/lab/Alert';
+import AlertTitle from '@material-ui/lab/AlertTitle';
+import { useSnackbar } from 'notistack';
+import React, { useState, useContext } from 'react';
+
+import Loader from 'components/common/Loader';
+import { AppContext } from 'context/AppContext';
+import {
+  EquipmentAssignmentStatus,
+  ProposalBookingStatus,
+} from 'generated/sdk';
+import { useDataApi } from 'hooks/common/useDataApi';
+import useScheduledEventsWithEquipments from 'hooks/scheduledEvent/useScheduledEventsWithEquipments';
+
+// import SelectTimeSlotsDialog from '../../proposalBooking/bookingSteps/equipmentBooking/SelectTimeSlotsDialog';
+import TimeSlotEquipmentTable from '../../proposalBooking/bookingSteps/equipmentBooking/TimeSlotEquipmentTable';
+import { ProposalBookingDialogStepProps } from '../TimeSlotBookingDialog';
+
+export type EquipmentTableRow = {
+  id: string;
+  name: string;
+  autoAccept: boolean;
+};
+
+const useStyles = makeStyles((theme) => ({
+  toolbarRoot: {
+    paddingLeft: theme.spacing(2),
+    paddingRight: theme.spacing(1),
+  },
+  title: {
+    flex: '1 1 100%',
+    alignItems: 'center',
+    display: 'flex',
+  },
+  spacingLeft: {
+    marginLeft: theme.spacing(2),
+  },
+  spacingTop: {
+    marginTop: theme.spacing(2),
+  },
+}));
+
+export default function EquipmentBookingStep({
+  activeStatus,
+  scheduledEvent,
+  handleNext,
+  handleBack,
+  handleSetActiveStepByStatus,
+  handleCloseDialog,
+}: ProposalBookingDialogStepProps) {
+  const isStepReadOnly = activeStatus !== ProposalBookingStatus.DRAFT;
+
+  const classes = useStyles();
+  const { enqueueSnackbar } = useSnackbar();
+  const [loading, setLoading] = useState(false);
+  const [equipmentDialog, setEquipmentDialog] = useState(false);
+  const {
+    loading: scheduledEventsLoading,
+    scheduledEvents,
+    refresh,
+  } = useScheduledEventsWithEquipments(scheduledEvent.id);
+
+  const isLoading = scheduledEventsLoading || loading;
+
+  const allEquipmentsAccepted = scheduledEvents.every((event) =>
+    event.equipments.every(
+      (equipment) => equipment.status === EquipmentAssignmentStatus.ACCEPTED
+    )
+  );
+
+  const handleEquipmentCloseDialog = () => {
+    setEquipmentDialog(false);
+    refresh();
+  };
+
+  const { showConfirmation } = useContext(AppContext);
+  const api = useDataApi();
+
+  const handleActivateSubmit = async () => {
+    showConfirmation({
+      message: (
+        <>
+          Are you sure you want to <strong>activate</strong> booking?
+        </>
+      ),
+      cb: async () => {
+        try {
+          setLoading(true);
+
+          const {
+            activateProposalBooking: { error },
+          } = await api().activateProposalBooking({
+            id: scheduledEvent.id,
+          });
+
+          if (error) {
+            enqueueSnackbar(getTranslation(error as ResourceId), {
+              variant: 'error',
+            });
+
+            setLoading(false);
+          } else {
+            handleNext();
+            handleSetActiveStepByStatus(ProposalBookingStatus.BOOKED);
+          }
+        } catch (e) {
+          // TODO
+          setLoading(false);
+          console.error(e);
+        }
+      },
+    });
+  };
+
+  const handleDeleteAssignment = (
+    equipmentId: string,
+    scheduledEventId: string
+  ) => {
+    showConfirmation({
+      message: (
+        <>
+          Are you sure you want to <strong>remove</strong> the selected
+          equipment?
+        </>
+      ),
+      cb: async () => {
+        setLoading(true);
+
+        const { deleteEquipmentAssignment: success } =
+          await api().deleteEquipmentAssignment({
+            deleteEquipmentAssignmentInput: {
+              equipmentId,
+              scheduledEventId,
+              proposalBookingId: scheduledEvent.id,
+            },
+          });
+
+        if (success) {
+          refresh();
+          enqueueSnackbar('Removed', { variant: 'success' });
+        } else {
+          enqueueSnackbar('Failed to remove selected assignment', {
+            variant: 'error',
+          });
+        }
+
+        setLoading(false);
+      },
+    });
+  };
+
+  return (
+    <>
+      {isLoading && <Loader />}
+
+      {/* {equipmentDialog && (
+        <SelectTimeSlotsDialog
+          isDialogOpen={equipmentDialog}
+          proposalBooking={proposalBooking}
+          closeDialog={handleEquipmentCloseDialog}
+        />
+      )} */}
+
+      <DialogContent>
+        <Toolbar className={classes.toolbarRoot}>
+          <Typography
+            className={classes.title}
+            variant="h6"
+            id="tableTitle"
+            component="div"
+          >
+            Time Slots with Equipments
+            <Button
+              variant="contained"
+              color="primary"
+              startIcon={<AddIcon />}
+              className={classes.spacingLeft}
+              onClick={() => setEquipmentDialog(true)}
+              data-cy="btn-book-equipment"
+              disabled={isStepReadOnly}
+            >
+              Book equipment
+            </Button>
+          </Typography>
+        </Toolbar>
+        <TimeSlotEquipmentTable
+          rows={scheduledEvents}
+          onDeleteAssignment={handleDeleteAssignment}
+          readOnly={isStepReadOnly}
+        />
+        {!allEquipmentsAccepted && (
+          <Alert
+            severity="warning"
+            className={classes.spacingTop}
+            data-cy="accepted-equipment-warning"
+          >
+            <AlertTitle>Warning</AlertTitle>
+            All booked equipments must be accepted before activating the booking
+          </Alert>
+        )}
+      </DialogContent>
+
+      <DialogActions>
+        <Button
+          color="primary"
+          onClick={handleCloseDialog}
+          data-cy="btn-close-dialog"
+        >
+          Close
+        </Button>
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={handleBack}
+          data-cy="btn-back"
+          disabled={isStepReadOnly}
+        >
+          Back
+        </Button>
+        <Button
+          variant="contained"
+          color="primary"
+          disabled={isStepReadOnly || !allEquipmentsAccepted}
+          onClick={handleActivateSubmit}
+        >
+          Activate booking
+        </Button>
+      </DialogActions>
+    </>
+  );
+}

--- a/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotFinalizeStep.tsx
+++ b/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotFinalizeStep.tsx
@@ -15,6 +15,7 @@ import Loader from 'components/common/Loader';
 import SplitButton from 'components/common/SplitButton';
 import { AppContext } from 'context/AppContext';
 import {
+  ProposalBooking,
   ProposalBookingFinalizeAction,
   ProposalBookingStatus,
 } from 'generated/sdk';
@@ -38,7 +39,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export default function FinalizeStep({
+export default function TimeSlotFinalizeStep({
   activeStatus,
   scheduledEvent,
   setScheduledEvent,
@@ -49,13 +50,14 @@ export default function FinalizeStep({
   handleSetActiveStepByStatus,
   handleCloseDialog,
 }: ProposalBookingDialogStepProps) {
+  const proposalBooking = scheduledEvent.proposalBooking as ProposalBooking;
   const isStepReadOnly = activeStatus !== ProposalBookingStatus.BOOKED;
 
   const classes = useStyles();
 
   // TODO: Query lost times by scheduled event id as well.
   const { loading, lostTimes } = useProposalBookingLostTimes(
-    scheduledEvent.proposalBooking!.id,
+    proposalBooking.id,
     scheduledEvent.id
   );
 
@@ -104,7 +106,7 @@ export default function FinalizeStep({
         bulkUpsertLostTimes: { error, lostTime: updatedLostTime },
       } = await api().bulkUpsertLostTimes({
         input: {
-          proposalBookingId: scheduledEvent.proposalBooking!.id,
+          proposalBookingId: proposalBooking.id,
           lostTimes: rows.map(({ startsAt, endsAt, id, newlyCreated }) => ({
             newlyCreated: newlyCreated,
             id: newlyCreated ? 0 : id,

--- a/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotFinalizeStep.tsx
+++ b/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotFinalizeStep.tsx
@@ -1,0 +1,294 @@
+import { getTranslation, ResourceId } from '@esss-swap/duo-localisation';
+import {
+  Button,
+  DialogActions,
+  DialogContent,
+  makeStyles,
+} from '@material-ui/core';
+import { Add as AddIcon, Save as SaveIcon } from '@material-ui/icons';
+import { Alert, AlertTitle } from '@material-ui/lab';
+import moment from 'moment';
+import { useSnackbar } from 'notistack';
+import React, { useContext, useEffect, useState } from 'react';
+
+import Loader from 'components/common/Loader';
+import SplitButton from 'components/common/SplitButton';
+import { AppContext } from 'context/AppContext';
+import {
+  ProposalBookingFinalizeAction,
+  ProposalBookingStatus,
+} from 'generated/sdk';
+import { useDataApi } from 'hooks/common/useDataApi';
+import useProposalBookingLostTimes from 'hooks/lostTime/useProposalBookingLostTimes';
+import { parseTzLessDateTime, toTzLessDateTime } from 'utils/date';
+import { hasOverlappingEvents } from 'utils/scheduledEvent';
+
+import TimeTable, { TimeTableRow } from '../../proposalBooking/TimeTable';
+import { ProposalBookingDialogStepProps } from '../TimeSlotBookingDialog';
+
+const useStyles = makeStyles((theme) => ({
+  spacing: {
+    display: 'flex',
+    alignItems: 'center',
+    margin: theme.spacing(3, 1, 1),
+    gap: theme.spacing(1),
+  },
+  spacingLeft: {
+    marginLeft: theme.spacing(2),
+  },
+}));
+
+export default function FinalizeStep({
+  activeStatus,
+  scheduledEvent,
+  isDirty,
+  handleSetDirty,
+  handleNext,
+  handleResetSteps,
+  handleSetActiveStepByStatus,
+  handleCloseDialog,
+}: ProposalBookingDialogStepProps) {
+  const isStepReadOnly = activeStatus !== ProposalBookingStatus.BOOKED;
+
+  const classes = useStyles();
+
+  // TODO: We should introduce new connection between scheduled event time slot and lost time. Now the connection is between proposal booking globally and lost times.
+  const { loading, lostTimes } = useProposalBookingLostTimes(scheduledEvent.id);
+
+  const { showConfirmation } = useContext(AppContext);
+  const { enqueueSnackbar } = useSnackbar();
+  const api = useDataApi();
+  const [rows, setRows] = useState<TimeTableRow[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if (!loading) {
+      setRows(
+        lostTimes.map(({ startsAt, endsAt, ...rest }) => ({
+          ...rest,
+          startsAt: parseTzLessDateTime(startsAt),
+          endsAt: parseTzLessDateTime(endsAt),
+        }))
+      );
+
+      setIsLoading(false);
+    }
+  }, [loading, lostTimes]);
+
+  const handleRowsChange = (cb: React.SetStateAction<TimeTableRow[]>) => {
+    !isDirty && handleSetDirty(true);
+    setRows(cb);
+  };
+
+  const handleAdd = () => {
+    handleRowsChange((rows) => [
+      ...rows,
+      {
+        id: `t-${Date.now()}`,
+        newlyCreated: true,
+        startsAt: moment().startOf('hour'),
+        endsAt: moment().startOf('hour').add(1, 'hour'),
+      },
+    ]);
+  };
+
+  const handleSaveSubmit = async () => {
+    try {
+      setIsLoading(true);
+
+      const {
+        bulkUpsertLostTimes: { error, lostTime: updatedLostTime },
+      } = await api().bulkUpsertLostTimes({
+        input: {
+          proposalBookingId: scheduledEvent.id,
+          lostTimes: rows.map(({ startsAt, endsAt, ...rest }) => ({
+            ...rest,
+            startsAt: toTzLessDateTime(startsAt),
+            endsAt: toTzLessDateTime(endsAt),
+          })),
+        },
+      });
+
+      if (error) {
+        enqueueSnackbar(getTranslation(error as ResourceId), {
+          variant: 'error',
+        });
+      } else {
+        updatedLostTime &&
+          setRows(
+            updatedLostTime.map(({ startsAt, endsAt, ...rest }) => ({
+              ...rest,
+              startsAt: parseTzLessDateTime(startsAt),
+              endsAt: parseTzLessDateTime(endsAt),
+            }))
+          );
+      }
+
+      handleSetDirty(false);
+    } catch (e) {
+      // TODO
+      console.error(e);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleSave = () => {
+    hasOverlappingEvents(rows)
+      ? showConfirmation({
+          message: (
+            <>
+              You have <strong>overlapping events</strong>, are you sure you
+              want to continue?
+            </>
+          ),
+          cb: handleSaveSubmit,
+        })
+      : handleSaveSubmit();
+  };
+
+  const handleFinalizeSubmit = async (
+    selectedKey: ProposalBookingFinalizeAction
+  ) => {
+    showConfirmation({
+      message: (
+        <>
+          Are you sure you want to{' '}
+          <strong>
+            {selectedKey === ProposalBookingFinalizeAction.CLOSE
+              ? 'close'
+              : 'restart'}
+          </strong>{' '}
+          the selected booking?
+        </>
+      ),
+      cb: async () => {
+        try {
+          setIsLoading(true);
+
+          const {
+            finalizeProposalBooking: { error },
+          } = await api().finalizeProposalBooking({
+            action: selectedKey,
+            id: scheduledEvent.id,
+          });
+
+          if (error) {
+            enqueueSnackbar(getTranslation(error as ResourceId), {
+              variant: 'error',
+            });
+
+            setIsLoading(false);
+          } else {
+            selectedKey === ProposalBookingFinalizeAction.CLOSE
+              ? handleNext()
+              : handleResetSteps();
+
+            handleSetActiveStepByStatus(
+              selectedKey === ProposalBookingFinalizeAction.CLOSE
+                ? ProposalBookingStatus.CLOSED
+                : ProposalBookingStatus.DRAFT
+            );
+          }
+        } catch (e) {
+          // TODO
+
+          setIsLoading(false);
+          console.error(e);
+        }
+      },
+    });
+  };
+
+  const handleFinalize = (selectedKey: ProposalBookingFinalizeAction) => {
+    isDirty
+      ? showConfirmation({
+          message: (
+            <>
+              You have <strong>unsaved work</strong>, are you sure you want to
+              continue?
+            </>
+          ),
+          cb: () => handleFinalizeSubmit(selectedKey),
+        })
+      : handleFinalizeSubmit(selectedKey);
+  };
+
+  return (
+    <>
+      {isLoading && <Loader />}
+
+      <DialogContent>
+        <TimeTable
+          selectable={!isStepReadOnly}
+          editable={!isStepReadOnly}
+          maxHeight={380}
+          rows={rows}
+          handleRowsChange={handleRowsChange}
+          titleComponent={
+            <>
+              Lost time
+              <Button
+                variant="contained"
+                color="primary"
+                startIcon={<AddIcon />}
+                className={classes.spacingLeft}
+                onClick={handleAdd}
+                data-cy="btn-add-lost-time"
+                disabled={isStepReadOnly}
+              >
+                Add
+              </Button>
+            </>
+          }
+        />
+        <div className={classes.spacing}>
+          <Button
+            variant="contained"
+            color="primary"
+            startIcon={<SaveIcon />}
+            onClick={handleSave}
+            data-cy="btn-save"
+            disabled={isStepReadOnly}
+          >
+            Save lost time
+          </Button>
+          <SplitButton
+            label="proposal-booking-finalization-strategy"
+            options={[
+              {
+                key: ProposalBookingFinalizeAction.CLOSE,
+                label: 'Close proposal booking',
+              },
+              {
+                key: ProposalBookingFinalizeAction.RESTART,
+                label: 'Restart the booking process',
+              },
+            ]}
+            onClick={handleFinalize}
+            disabled={isStepReadOnly}
+            dropdownDisabled={isStepReadOnly}
+          />
+        </div>
+        <div></div>
+        {!isStepReadOnly && (
+          <div>
+            <Alert severity="warning">
+              <AlertTitle>Warning</AlertTitle>
+              Closing proposal booking disallows any further edit
+            </Alert>
+          </div>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button
+          color="primary"
+          onClick={handleCloseDialog}
+          data-cy="btn-close-dialog"
+        >
+          Close
+        </Button>
+      </DialogActions>
+    </>
+  );
+}

--- a/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotFinalizeStep.tsx
+++ b/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotFinalizeStep.tsx
@@ -84,7 +84,7 @@ export default function FinalizeStep({
     handleRowsChange((rows) => [
       ...rows,
       {
-        id: `t-${Date.now()}`,
+        id: Date.now(),
         newlyCreated: true,
         startsAt: moment().startOf('hour'),
         endsAt: moment().startOf('hour').add(1, 'hour'),
@@ -101,8 +101,10 @@ export default function FinalizeStep({
       } = await api().bulkUpsertLostTimes({
         input: {
           proposalBookingId: scheduledEvent.id,
-          lostTimes: rows.map(({ startsAt, endsAt, ...rest }) => ({
+          lostTimes: rows.map(({ startsAt, endsAt, id, ...rest }) => ({
             ...rest,
+            id: id,
+            scheduledEventId: id,
             startsAt: toTzLessDateTime(startsAt),
             endsAt: toTzLessDateTime(endsAt),
           })),

--- a/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotFinalizeStep.tsx
+++ b/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotFinalizeStep.tsx
@@ -169,10 +169,12 @@ export default function FinalizeStep({
           setIsLoading(true);
 
           const {
-            finalizeProposalBooking: { error },
-          } = await api().finalizeProposalBooking({
-            action: selectedKey,
-            id: scheduledEvent.id,
+            finalizeScheduledEvent: { error },
+          } = await api().finalizeScheduledEvent({
+            input: {
+              action: selectedKey,
+              id: scheduledEvent.id,
+            },
           });
 
           if (error) {

--- a/src/filters/scheduledEvent/scheduledEventsFilter.ts
+++ b/src/filters/scheduledEvent/scheduledEventsFilter.ts
@@ -5,7 +5,7 @@ import { ScheduledEventFilter } from 'generated/sdk';
 import { toTzLessDateTime } from 'utils/date';
 
 export default function generateScheduledEventFilter(
-  instrumentId: string | null,
+  instrumentId: number | null,
   startsAt: Date,
   activeView: ExtendedView
 ): ScheduledEventFilter {

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -3527,6 +3527,7 @@ export type GetProposalBookingScheduledEventsQuery = (
 export type GetScheduledEventWithEquipmentsQueryVariables = Exact<{
   proposalBookingId: Scalars['Int'];
   scheduledEventId: Scalars['Int'];
+  scheduledEventFilter: ProposalBookingScheduledEventFilter;
 }>;
 
 
@@ -3537,8 +3538,11 @@ export type GetScheduledEventWithEquipmentsQuery = (
     & Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt' | 'status'>
     & { proposalBooking: Maybe<(
       { __typename?: 'ProposalBooking' }
-      & Pick<ProposalBooking, 'status'>
-      & { proposal: Maybe<(
+      & Pick<ProposalBooking, 'id' | 'status' | 'allocatedTime'>
+      & { scheduledEvents: Array<(
+        { __typename?: 'ScheduledEvent' }
+        & Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt'>
+      )>, proposal: Maybe<(
         { __typename?: 'Proposal' }
         & Pick<Proposal, 'primaryKey' | 'title' | 'proposalId'>
         & { proposer: Maybe<(
@@ -3965,7 +3969,7 @@ export const GetProposalBookingScheduledEventsDocument = gql`
 }
     `;
 export const GetScheduledEventWithEquipmentsDocument = gql`
-    query getScheduledEventWithEquipments($proposalBookingId: Int!, $scheduledEventId: Int!) {
+    query getScheduledEventWithEquipments($proposalBookingId: Int!, $scheduledEventId: Int!, $scheduledEventFilter: ProposalBookingScheduledEventFilter!) {
   proposalBookingScheduledEvent(
     proposalBookingId: $proposalBookingId
     scheduledEventId: $scheduledEventId
@@ -3975,7 +3979,14 @@ export const GetScheduledEventWithEquipmentsDocument = gql`
     endsAt
     status
     proposalBooking {
+      id
       status
+      allocatedTime
+      scheduledEvents(filter: $scheduledEventFilter) {
+        id
+        startsAt
+        endsAt
+      }
       proposal {
         primaryKey
         title

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -94,9 +94,9 @@ export type AssignChairOrSecretaryToSepInput = {
 };
 
 export type AssignEquipmentsToScheduledEventInput = {
-  scheduledEventId: Scalars['ID'];
-  proposalBookingId: Scalars['ID'];
-  equipmentIds: Array<Scalars['ID']>;
+  scheduledEventId: Scalars['Int'];
+  proposalBookingId: Scalars['Int'];
+  equipmentIds: Array<Scalars['Int']>;
 };
 
 export type AssignInstrumentsToCallInput = {
@@ -141,12 +141,12 @@ export type BooleanConfig = {
 };
 
 export type BulkUpsertLostTimesInput = {
-  proposalBookingId: Scalars['ID'];
+  proposalBookingId: Scalars['Int'];
   lostTimes: Array<SimpleLostTimeInput>;
 };
 
 export type BulkUpsertScheduledEventsInput = {
-  proposalBookingId: Scalars['ID'];
+  proposalBookingId: Scalars['Int'];
   scheduledEvents: Array<SimpleScheduledEventInput>;
 };
 
@@ -170,9 +170,10 @@ export type Call = {
   surveyComment: Scalars['String'];
   proposalWorkflowId: Maybe<Scalars['Int']>;
   allocationTimeUnit: AllocationTimeUnits;
-  templateId: Maybe<Scalars['Int']>;
+  templateId: Scalars['Int'];
   instruments: Array<InstrumentWithAvailabilityTime>;
   proposalWorkflow: Maybe<ProposalWorkflow>;
+  template: Template;
   proposalCount: Scalars['Int'];
   isActive: Scalars['Boolean'];
 };
@@ -202,14 +203,14 @@ export type CheckExternalTokenWrap = {
   token: Maybe<Scalars['String']>;
 };
 
-export type CloneProposalInput = {
+export type CloneProposalsInput = {
   callId: Scalars['Int'];
-  proposalToClonePk: Scalars['Int'];
+  proposalsToClonePk: Array<Scalars['Int']>;
 };
 
 export type ConfirmEquipmentAssignmentInput = {
-  scheduledEventId: Scalars['ID'];
-  equipmentId: Scalars['ID'];
+  scheduledEventId: Scalars['Int'];
+  equipmentId: Scalars['Int'];
   newStatus: EquipmentAssignmentStatus;
 };
 
@@ -235,8 +236,8 @@ export type CreateCallInput = {
   cycleComment: Scalars['String'];
   surveyComment: Scalars['String'];
   allocationTimeUnit: AllocationTimeUnits;
-  proposalWorkflowId?: Maybe<Scalars['Int']>;
-  templateId?: Maybe<Scalars['Int']>;
+  proposalWorkflowId: Scalars['Int'];
+  templateId: Scalars['Int'];
 };
 
 export type CreateProposalStatusInput = {
@@ -270,7 +271,8 @@ export enum DataType {
   NUMBER_INPUT = 'NUMBER_INPUT',
   SHIPMENT_BASIS = 'SHIPMENT_BASIS',
   RICH_TEXT_INPUT = 'RICH_TEXT_INPUT',
-  VISIT_BASIS = 'VISIT_BASIS'
+  VISIT_BASIS = 'VISIT_BASIS',
+  RISK_ASSESSMENT_BASIS = 'RISK_ASSESSMENT_BASIS'
 }
 
 export type DateConfig = {
@@ -296,9 +298,9 @@ export type DeleteApiAccessTokenInput = {
 };
 
 export type DeleteEquipmentAssignmentInput = {
-  scheduledEventId: Scalars['ID'];
-  proposalBookingId: Scalars['ID'];
-  equipmentId: Scalars['ID'];
+  scheduledEventId: Scalars['Int'];
+  proposalBookingId: Scalars['Int'];
+  equipmentId: Scalars['Int'];
 };
 
 export type DeleteProposalWorkflowStatusInput = {
@@ -333,7 +335,7 @@ export type Entry = {
 
 export type Equipment = {
   __typename?: 'Equipment';
-  id: Scalars['ID'];
+  id: Scalars['Int'];
   owner: Maybe<User>;
   createdAt: Scalars['DateTime'];
   updatedAt: Scalars['DateTime'];
@@ -371,13 +373,13 @@ export type EquipmentResponseWrap = {
 };
 
 export type EquipmentResponsibleInput = {
-  equipmentId: Scalars['ID'];
+  equipmentId: Scalars['Int'];
   userIds: Array<Scalars['Int']>;
 };
 
 export type EquipmentWithAssignmentStatus = {
   __typename?: 'EquipmentWithAssignmentStatus';
-  id: Scalars['ID'];
+  id: Scalars['Int'];
   owner: Maybe<User>;
   createdAt: Scalars['DateTime'];
   updatedAt: Scalars['DateTime'];
@@ -425,6 +427,7 @@ export enum Event {
   PROPOSAL_MANAGEMENT_DECISION_SUBMITTED = 'PROPOSAL_MANAGEMENT_DECISION_SUBMITTED',
   PROPOSAL_INSTRUMENT_SUBMITTED = 'PROPOSAL_INSTRUMENT_SUBMITTED',
   PROPOSAL_ACCEPTED = 'PROPOSAL_ACCEPTED',
+  PROPOSAL_RESERVED = 'PROPOSAL_RESERVED',
   PROPOSAL_REJECTED = 'PROPOSAL_REJECTED',
   PROPOSAL_STATUS_UPDATED = 'PROPOSAL_STATUS_UPDATED',
   CALL_ENDED = 'CALL_ENDED',
@@ -446,7 +449,8 @@ export enum Event {
   PROPOSAL_NOTIFIED = 'PROPOSAL_NOTIFIED',
   PROPOSAL_CLONED = 'PROPOSAL_CLONED',
   PROPOSAL_STATUS_CHANGED_BY_WORKFLOW = 'PROPOSAL_STATUS_CHANGED_BY_WORKFLOW',
-  PROPOSAL_STATUS_CHANGED_BY_USER = 'PROPOSAL_STATUS_CHANGED_BY_USER'
+  PROPOSAL_STATUS_CHANGED_BY_USER = 'PROPOSAL_STATUS_CHANGED_BY_USER',
+  TOPIC_ANSWERED = 'TOPIC_ANSWERED'
 }
 
 export type EventLog = {
@@ -483,7 +487,7 @@ export type FieldConditionInput = {
   params: Scalars['String'];
 };
 
-export type FieldConfig = BooleanConfig | DateConfig | EmbellishmentConfig | FileUploadConfig | SelectionFromOptionsConfig | TextInputConfig | SampleBasisConfig | SubtemplateConfig | ProposalBasisConfig | IntervalConfig | NumberInputConfig | ShipmentBasisConfig | RichTextInputConfig | VisitBasisConfig;
+export type FieldConfig = BooleanConfig | DateConfig | EmbellishmentConfig | FileUploadConfig | SelectionFromOptionsConfig | TextInputConfig | SampleBasisConfig | SubTemplateConfig | ProposalBasisConfig | IntervalConfig | NumberInputConfig | ShipmentBasisConfig | RichTextInputConfig | VisitBasisConfig | RiskAssessmentBasisConfig;
 
 export type FieldDependency = {
   __typename?: 'FieldDependency';
@@ -595,8 +599,9 @@ export type IntervalConfig = {
 
 export type LostTime = {
   __typename?: 'LostTime';
-  id: Scalars['ID'];
-  proposalBookingId: Scalars['ID'];
+  id: Scalars['Int'];
+  proposalBookingId: Scalars['Int'];
+  scheduledEventId: Scalars['Int'];
   createdAt: Scalars['DateTime'];
   updatedAt: Scalars['DateTime'];
   startsAt: Scalars['TzLessDateTime'];
@@ -637,7 +642,7 @@ export type Mutation = {
   setInstrumentAvailabilityTime: SuccessResponseWrap;
   submitInstrument: SuccessResponseWrap;
   administrationProposal: ProposalResponseWrap;
-  cloneProposal: ProposalResponseWrap;
+  cloneProposals: ProposalsResponseWrap;
   updateProposal: ProposalResponseWrap;
   addProposalWorkflowStatus: ProposalWorkflowConnectionResponseWrap;
   addStatusChangingEventsToConnection: ProposalStatusChangingEventResponseWrap;
@@ -654,6 +659,8 @@ export type Mutation = {
   addUserForReview: ReviewResponseWrap;
   submitProposalsReview: SuccessResponseWrap;
   updateTechnicalReviewAssignee: ProposalsResponseWrap;
+  createRiskAssessment: RiskAssessmentResponseWrap;
+  updateRiskAssessment: RiskAssessmentResponseWrap;
   createSample: SampleResponseWrap;
   updateSample: SampleResponseWrap;
   assignChairOrSecretary: SepResponseWrap;
@@ -688,6 +695,9 @@ export type Mutation = {
   updateUserRoles: UserResponseWrap;
   setUserEmailVerified: UserResponseWrap;
   setUserNotPlaceholder: UserResponseWrap;
+  createVisit: VisitResponseWrap;
+  updateVisit: VisitResponseWrap;
+  updateVisitRegistration: VisitRegistrationResponseWrap;
   addClientLog: SuccessResponseWrap;
   addSamplesToShipment: ShipmentResponseWrap;
   addTechnicalReview: TechnicalReviewResponseWrap;
@@ -696,12 +706,13 @@ export type Mutation = {
   cloneSample: SampleResponseWrap;
   cloneTemplate: TemplateResponseWrap;
   createProposal: ProposalResponseWrap;
-  createVisit: VisitResponseWrap;
+  createVisitRegistrationQuestionary: VisitRegistrationResponseWrap;
   deleteCall: CallResponseWrap;
   deleteInstitution: InstitutionResponseWrap;
   deleteInstrument: InstrumentResponseWrap;
   deleteProposal: ProposalResponseWrap;
   deleteQuestion: QuestionResponseWrap;
+  deleteRiskAssessment: RiskAssessmentResponseWrap;
   deleteSample: SampleResponseWrap;
   deleteSEP: SepResponseWrap;
   deleteShipment: ShipmentResponseWrap;
@@ -727,7 +738,6 @@ export type Mutation = {
   token: TokenResponseWrap;
   selectRole: TokenResponseWrap;
   updatePassword: BasicUserDetailsResponseWrap;
-  updateVisit: VisitResponseWrap;
   createEquipment: EquipmentResponseWrap;
   updateEquipment: EquipmentResponseWrap;
   assignToScheduledEvents: Scalars['Boolean'];
@@ -866,8 +876,8 @@ export type MutationAdministrationProposalArgs = {
 };
 
 
-export type MutationCloneProposalArgs = {
-  cloneProposalInput: CloneProposalInput;
+export type MutationCloneProposalsArgs = {
+  cloneProposalsInput: CloneProposalsInput;
 };
 
 
@@ -963,6 +973,17 @@ export type MutationSubmitProposalsReviewArgs = {
 export type MutationUpdateTechnicalReviewAssigneeArgs = {
   userId: Scalars['Int'];
   proposalPks: Array<Scalars['Int']>;
+};
+
+
+export type MutationCreateRiskAssessmentArgs = {
+  proposalPk: Scalars['Int'];
+};
+
+
+export type MutationUpdateRiskAssessmentArgs = {
+  riskAssessmentId: Scalars['Int'];
+  status?: Maybe<RiskAssessmentStatus>;
 };
 
 
@@ -1063,6 +1084,7 @@ export type MutationUpdateSepTimeAllocationArgs = {
 export type MutationCreateShipmentArgs = {
   title: Scalars['String'];
   proposalPk: Scalars['Int'];
+  visitId: Scalars['Int'];
 };
 
 
@@ -1235,6 +1257,30 @@ export type MutationSetUserNotPlaceholderArgs = {
 };
 
 
+export type MutationCreateVisitArgs = {
+  proposalPk: Scalars['Int'];
+  scheduledEventId: Scalars['Int'];
+  team: Array<Scalars['Int']>;
+  teamLeadUserId: Scalars['Int'];
+};
+
+
+export type MutationUpdateVisitArgs = {
+  visitId: Scalars['Int'];
+  status?: Maybe<VisitStatus>;
+  proposalPkAndEventId?: Maybe<ProposalPkAndEventId>;
+  team?: Maybe<Array<Scalars['Int']>>;
+  teamLeadUserId?: Maybe<Scalars['Int']>;
+};
+
+
+export type MutationUpdateVisitRegistrationArgs = {
+  visitId: Scalars['Int'];
+  trainingExpiryDate?: Maybe<Scalars['DateTime']>;
+  isRegistrationSubmitted?: Maybe<Scalars['Boolean']>;
+};
+
+
 export type MutationAddClientLogArgs = {
   error: Scalars['String'];
 };
@@ -1271,9 +1317,8 @@ export type MutationCreateProposalArgs = {
 };
 
 
-export type MutationCreateVisitArgs = {
-  proposalPk: Scalars['Int'];
-  team?: Maybe<Array<Scalars['Int']>>;
+export type MutationCreateVisitRegistrationQuestionaryArgs = {
+  visitId: Scalars['Int'];
 };
 
 
@@ -1299,6 +1344,11 @@ export type MutationDeleteProposalArgs = {
 
 export type MutationDeleteQuestionArgs = {
   questionId: Scalars['String'];
+};
+
+
+export type MutationDeleteRiskAssessmentArgs = {
+  riskAssessmentId: Scalars['Int'];
 };
 
 
@@ -1433,14 +1483,6 @@ export type MutationUpdatePasswordArgs = {
 };
 
 
-export type MutationUpdateVisitArgs = {
-  visitId: Scalars['Int'];
-  status?: Maybe<VisitStatus>;
-  proposalPk?: Maybe<Scalars['Int']>;
-  team?: Maybe<Array<Scalars['Int']>>;
-};
-
-
 export type MutationCreateEquipmentArgs = {
   newEquipmentInput: EquipmentInput;
 };
@@ -1448,7 +1490,7 @@ export type MutationCreateEquipmentArgs = {
 
 export type MutationUpdateEquipmentArgs = {
   updateEquipmentInput: EquipmentInput;
-  id: Scalars['ID'];
+  id: Scalars['Int'];
 };
 
 
@@ -1488,13 +1530,13 @@ export type MutationBulkUpsertScheduledEventsArgs = {
 
 
 export type MutationFinalizeProposalBookingArgs = {
-  id: Scalars['ID'];
+  id: Scalars['Int'];
   action: ProposalBookingFinalizeAction;
 };
 
 
 export type MutationActivateProposalBookingArgs = {
-  id: Scalars['ID'];
+  id: Scalars['Int'];
 };
 
 
@@ -1507,7 +1549,7 @@ export type NewScheduledEventInput = {
   startsAt: Scalars['TzLessDateTime'];
   endsAt: Scalars['TzLessDateTime'];
   description?: Maybe<Scalars['String']>;
-  instrumentId: Scalars['ID'];
+  instrumentId: Scalars['Int'];
 };
 
 export type NextProposalStatus = {
@@ -1613,10 +1655,11 @@ export type Proposal = {
   instrument: Maybe<Instrument>;
   sep: Maybe<Sep>;
   call: Maybe<Call>;
-  questionary: Maybe<Questionary>;
+  questionary: Questionary;
   sepMeetingDecision: Maybe<SepMeetingDecision>;
   samples: Maybe<Array<Sample>>;
   visits: Maybe<Array<Visit>>;
+  riskAssessment: Maybe<RiskAssessment>;
   proposalBooking: Maybe<ProposalBooking>;
 };
 
@@ -1632,7 +1675,7 @@ export type ProposalBasisConfig = {
 
 export type ProposalBooking = {
   __typename?: 'ProposalBooking';
-  id: Scalars['ID'];
+  id: Scalars['Int'];
   call: Maybe<Call>;
   proposal: Maybe<Proposal>;
   createdAt: Scalars['DateTime'];
@@ -1682,6 +1725,11 @@ export type ProposalEvent = {
   __typename?: 'ProposalEvent';
   name: Event;
   description: Maybe<Scalars['String']>;
+};
+
+export type ProposalPkAndEventId = {
+  proposalPK: Scalars['Int'];
+  scheduledEventId: Scalars['Int'];
 };
 
 export type ProposalPkWithCallId = {
@@ -1754,6 +1802,7 @@ export type ProposalTemplate = {
 
 export type ProposalTemplatesFilter = {
   isArchived?: Maybe<Scalars['Boolean']>;
+  templateIds?: Maybe<Array<Scalars['Int']>>;
 };
 
 export type ProposalView = {
@@ -1799,7 +1848,7 @@ export type ProposalWorkflowConnection = {
   nextProposalStatusId: Maybe<Scalars['Int']>;
   prevProposalStatusId: Maybe<Scalars['Int']>;
   droppableGroupId: Scalars['String'];
-  statusChangingEvents: Array<StatusChangingEvent>;
+  statusChangingEvents: Maybe<Array<StatusChangingEvent>>;
 };
 
 export type ProposalWorkflowConnectionGroup = {
@@ -1862,6 +1911,7 @@ export type Query = {
   myVisits: Array<Visit>;
   activeTemplateId: Maybe<Scalars['Int']>;
   basicUserDetails: Maybe<BasicUserDetails>;
+  basicUserDetailsByEmail: Maybe<BasicUserDetails>;
   blankQuestionarySteps: Maybe<Array<QuestionaryStep>>;
   call: Maybe<Call>;
   checkEmailExist: Maybe<Scalars['Boolean']>;
@@ -1895,6 +1945,7 @@ export type Query = {
   questionary: Maybe<Questionary>;
   review: Maybe<Review>;
   proposalReviews: Maybe<Array<Review>>;
+  riskAssessment: RiskAssessment;
   roles: Maybe<Array<Role>>;
   sample: Maybe<Sample>;
   samplesByCallId: Maybe<Array<Sample>>;
@@ -1917,6 +1968,8 @@ export type Query = {
   user: Maybe<User>;
   me: Maybe<User>;
   users: Maybe<UserQueryResult>;
+  previousCollaborators: Maybe<UserQueryResult>;
+  visitRegistration: Maybe<VisitRegistration>;
   visit: Maybe<Visit>;
   scheduledEvents: Array<ScheduledEvent>;
   scheduledEvent: Maybe<ScheduledEvent>;
@@ -1985,6 +2038,12 @@ export type QueryActiveTemplateIdArgs = {
 
 export type QueryBasicUserDetailsArgs = {
   id: Scalars['Int'];
+};
+
+
+export type QueryBasicUserDetailsByEmailArgs = {
+  role?: Maybe<UserRole>;
+  email: Scalars['String'];
 };
 
 
@@ -2112,6 +2171,11 @@ export type QueryProposalReviewsArgs = {
 };
 
 
+export type QueryRiskAssessmentArgs = {
+  riskAssessmentId: Scalars['Int'];
+};
+
+
 export type QuerySampleArgs = {
   sampleId: Scalars['Int'];
 };
@@ -2198,6 +2262,21 @@ export type QueryUsersArgs = {
 };
 
 
+export type QueryPreviousCollaboratorsArgs = {
+  filter?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  userRole?: Maybe<UserRole>;
+  subtractUsers?: Maybe<Array<Maybe<Scalars['Int']>>>;
+  userId: Scalars['Int'];
+};
+
+
+export type QueryVisitRegistrationArgs = {
+  visitId: Scalars['Int'];
+};
+
+
 export type QueryVisitArgs = {
   visitId: Scalars['Int'];
 };
@@ -2209,18 +2288,18 @@ export type QueryScheduledEventsArgs = {
 
 
 export type QueryScheduledEventArgs = {
-  id: Scalars['ID'];
+  id: Scalars['Int'];
 };
 
 
 export type QueryProposalBookingScheduledEventsArgs = {
-  proposalBookingId: Scalars['ID'];
+  proposalBookingId: Scalars['Int'];
 };
 
 
 export type QueryProposalBookingScheduledEventArgs = {
-  scheduledEventId: Scalars['ID'];
-  proposalBookingId: Scalars['ID'];
+  scheduledEventId: Scalars['Int'];
+  proposalBookingId: Scalars['Int'];
 };
 
 
@@ -2230,27 +2309,27 @@ export type QueryEquipmentsArgs = {
 
 
 export type QueryAvailableEquipmentsArgs = {
-  scheduledEventId: Scalars['ID'];
+  scheduledEventId: Scalars['Int'];
 };
 
 
 export type QueryEquipmentArgs = {
-  id: Scalars['ID'];
+  id: Scalars['Int'];
 };
 
 
 export type QueryProposalBookingLostTimesArgs = {
-  proposalBookingId: Scalars['ID'];
+  proposalBookingId: Scalars['Int'];
 };
 
 
 export type QueryInstrumentProposalBookingsArgs = {
-  instrumentId: Scalars['ID'];
+  instrumentId: Scalars['Int'];
 };
 
 
 export type QueryProposalBookingArgs = {
-  id: Scalars['ID'];
+  id: Scalars['Int'];
 };
 
 export type Question = {
@@ -2412,6 +2491,34 @@ export type RichTextInputConfig = {
   max: Maybe<Scalars['Int']>;
 };
 
+export type RiskAssessment = {
+  __typename?: 'RiskAssessment';
+  riskAssessmentId: Scalars['Int'];
+  proposalPk: Scalars['Int'];
+  creatorUserId: Scalars['Int'];
+  questionaryId: Scalars['Int'];
+  status: RiskAssessmentStatus;
+  questionary: Questionary;
+};
+
+export type RiskAssessmentBasisConfig = {
+  __typename?: 'RiskAssessmentBasisConfig';
+  small_label: Scalars['String'];
+  required: Scalars['Boolean'];
+  tooltip: Scalars['String'];
+};
+
+export type RiskAssessmentResponseWrap = {
+  __typename?: 'RiskAssessmentResponseWrap';
+  rejection: Maybe<Rejection>;
+  riskAssessment: Maybe<RiskAssessment>;
+};
+
+export enum RiskAssessmentStatus {
+  DRAFT = 'DRAFT',
+  SUBMITTED = 'SUBMITTED'
+}
+
 export type Role = {
   __typename?: 'Role';
   id: Scalars['Int'];
@@ -2536,7 +2643,7 @@ export type SaveSepMeetingDecisionInput = {
 
 export type ScheduledEvent = {
   __typename?: 'ScheduledEvent';
-  id: Scalars['ID'];
+  id: Scalars['Int'];
   createdAt: Scalars['DateTime'];
   updatedAt: Scalars['DateTime'];
   bookingType: ScheduledEventBookingType;
@@ -2547,9 +2654,11 @@ export type ScheduledEvent = {
   description: Maybe<Scalars['String']>;
   instrument: Maybe<Instrument>;
   equipmentId: Maybe<Scalars['Int']>;
+  status: ProposalBookingStatus;
   equipments: Array<EquipmentWithAssignmentStatus>;
   equipmentAssignmentStatus: Maybe<EquipmentAssignmentStatus>;
   proposalBooking: Maybe<ProposalBooking>;
+  visit: Maybe<Visit>;
 };
 
 export enum ScheduledEventBookingType {
@@ -2563,7 +2672,7 @@ export enum ScheduledEventBookingType {
 export type ScheduledEventFilter = {
   startsAt: Scalars['TzLessDateTime'];
   endsAt: Scalars['TzLessDateTime'];
-  instrumentId?: Maybe<Scalars['ID']>;
+  instrumentId?: Maybe<Scalars['Int']>;
 };
 
 export type ScheduledEventResponseWrap = {
@@ -2613,12 +2722,27 @@ export type SepMeetingDecisionResponseWrap = {
 export type Settings = {
   __typename?: 'Settings';
   id: SettingsId;
-  settingsValue: Scalars['String'];
-  description: Scalars['String'];
+  settingsValue: Maybe<Scalars['String']>;
+  description: Maybe<Scalars['String']>;
 };
 
 export enum SettingsId {
-  EXTERNAL_AUTH_LOGIN_URL = 'EXTERNAL_AUTH_LOGIN_URL'
+  EXTERNAL_AUTH_LOGIN_URL = 'EXTERNAL_AUTH_LOGIN_URL',
+  PROFILE_PAGE_LINK = 'PROFILE_PAGE_LINK',
+  PALETTE_PRIMARY_DARK = 'PALETTE_PRIMARY_DARK',
+  PALETTE_PRIMARY_MAIN = 'PALETTE_PRIMARY_MAIN',
+  PALETTE_PRIMARY_ACCENT = 'PALETTE_PRIMARY_ACCENT',
+  PALETTE_PRIMARY_LIGHT = 'PALETTE_PRIMARY_LIGHT',
+  PALETTE_PRIMARY_CONTRAST = 'PALETTE_PRIMARY_CONTRAST',
+  PALETTE_SECONDARY_DARK = 'PALETTE_SECONDARY_DARK',
+  PALETTE_SECONDARY_MAIN = 'PALETTE_SECONDARY_MAIN',
+  PALETTE_SECONDARY_LIGHT = 'PALETTE_SECONDARY_LIGHT',
+  PALETTE_SECONDARY_CONTRAST = 'PALETTE_SECONDARY_CONTRAST',
+  PALETTE_ERROR_MAIN = 'PALETTE_ERROR_MAIN',
+  PALETTE_SUCCESS_MAIN = 'PALETTE_SUCCESS_MAIN',
+  PALETTE_WARNING_MAIN = 'PALETTE_WARNING_MAIN',
+  PALETTE_INFO_MAIN = 'PALETTE_INFO_MAIN',
+  HEADER_LOGO_FILENAME = 'HEADER_LOGO_FILENAME'
 }
 
 export type Shipment = {
@@ -2629,6 +2753,7 @@ export type Shipment = {
   status: ShipmentStatus;
   externalRef: Maybe<Scalars['String']>;
   questionaryId: Scalars['Int'];
+  visitId: Scalars['Int'];
   creatorId: Scalars['Int'];
   created: Scalars['DateTime'];
   questionary: Questionary;
@@ -2662,17 +2787,19 @@ export type ShipmentsFilter = {
   status?: Maybe<ShipmentStatus>;
   externalRef?: Maybe<Scalars['String']>;
   shipmentIds?: Maybe<Array<Scalars['Int']>>;
+  visitId?: Maybe<Scalars['Int']>;
 };
 
 export type SimpleLostTimeInput = {
-  id: Scalars['ID'];
+  id: Scalars['Int'];
   startsAt: Scalars['TzLessDateTime'];
   endsAt: Scalars['TzLessDateTime'];
   newlyCreated?: Maybe<Scalars['Boolean']>;
+  scheduledEventId: Scalars['Int'];
 };
 
 export type SimpleScheduledEventInput = {
-  id: Scalars['ID'];
+  id: Scalars['Int'];
   startsAt: Scalars['TzLessDateTime'];
   endsAt: Scalars['TzLessDateTime'];
   newlyCreated?: Maybe<Scalars['Boolean']>;
@@ -2683,6 +2810,17 @@ export type StatusChangingEvent = {
   statusChangingEventId: Scalars['Int'];
   proposalWorkflowConnectionId: Scalars['Int'];
   statusChangingEvent: Scalars['String'];
+};
+
+export type SubTemplateConfig = {
+  __typename?: 'SubTemplateConfig';
+  minEntries: Maybe<Scalars['Int']>;
+  maxEntries: Maybe<Scalars['Int']>;
+  templateId: Maybe<Scalars['Int']>;
+  templateCategory: Scalars['String'];
+  addEntryButtonLabel: Scalars['String'];
+  small_label: Scalars['String'];
+  required: Scalars['Boolean'];
 };
 
 export type SubmitProposalsReviewInput = {
@@ -2697,17 +2835,6 @@ export type SubmitTechnicalReviewInput = {
   status?: Maybe<TechnicalReviewStatus>;
   submitted: Scalars['Boolean'];
   reviewerId: Scalars['Int'];
-};
-
-export type SubtemplateConfig = {
-  __typename?: 'SubtemplateConfig';
-  minEntries: Maybe<Scalars['Int']>;
-  maxEntries: Maybe<Scalars['Int']>;
-  templateId: Maybe<Scalars['Int']>;
-  templateCategory: Scalars['String'];
-  addEntryButtonLabel: Scalars['String'];
-  small_label: Scalars['String'];
-  required: Scalars['Boolean'];
 };
 
 export type SuccessResponseWrap = {
@@ -2764,7 +2891,8 @@ export enum TemplateCategoryId {
   PROPOSAL_QUESTIONARY = 'PROPOSAL_QUESTIONARY',
   SAMPLE_DECLARATION = 'SAMPLE_DECLARATION',
   SHIPMENT_DECLARATION = 'SHIPMENT_DECLARATION',
-  VISIT = 'VISIT'
+  VISIT = 'VISIT',
+  RISK_ASSESSMENT = 'RISK_ASSESSMENT'
 }
 
 export type TemplateResponseWrap = {
@@ -2865,11 +2993,11 @@ export type UpdateCallInput = {
   cycleComment: Scalars['String'];
   surveyComment: Scalars['String'];
   allocationTimeUnit: AllocationTimeUnits;
-  proposalWorkflowId?: Maybe<Scalars['Int']>;
+  proposalWorkflowId: Scalars['Int'];
   callEnded?: Maybe<Scalars['Int']>;
   callReviewEnded?: Maybe<Scalars['Int']>;
   callSEPReviewEnded?: Maybe<Scalars['Int']>;
-  templateId?: Maybe<Scalars['Int']>;
+  templateId: Scalars['Int'];
 };
 
 export type UpdateProposalStatusInput = {
@@ -2963,11 +3091,12 @@ export type Visit = {
   id: Scalars['Int'];
   proposalPk: Scalars['Int'];
   status: VisitStatus;
-  questionaryId: Scalars['Int'];
-  visitorId: Scalars['Int'];
+  creatorId: Scalars['Int'];
+  teamLeadUserId: Scalars['Int'];
   proposal: Proposal;
-  team: Array<BasicUserDetails>;
-  questionary: Questionary;
+  registrations: Array<VisitRegistration>;
+  teamLead: BasicUserDetails;
+  shipments: Array<Shipment>;
 };
 
 export type VisitBasisConfig = {
@@ -2975,6 +3104,23 @@ export type VisitBasisConfig = {
   small_label: Scalars['String'];
   required: Scalars['Boolean'];
   tooltip: Scalars['String'];
+};
+
+export type VisitRegistration = {
+  __typename?: 'VisitRegistration';
+  userId: Scalars['Int'];
+  visitId: Scalars['Int'];
+  registrationQuestionaryId: Maybe<Scalars['Int']>;
+  isRegistrationSubmitted: Scalars['Boolean'];
+  trainingExpiryDate: Maybe<Scalars['DateTime']>;
+  user: BasicUserDetails;
+  questionary: Questionary;
+};
+
+export type VisitRegistrationResponseWrap = {
+  __typename?: 'VisitRegistrationResponseWrap';
+  rejection: Maybe<Rejection>;
+  registration: Maybe<VisitRegistration>;
 };
 
 export type VisitResponseWrap = {
@@ -2990,9 +3136,9 @@ export enum VisitStatus {
 }
 
 export type VisitsFilter = {
-  visitorId?: Maybe<Scalars['Int']>;
-  questionaryId?: Maybe<Scalars['Int']>;
+  creatorId?: Maybe<Scalars['Int']>;
   proposalPk?: Maybe<Scalars['Int']>;
+  scheduledEventId?: Maybe<Scalars['Int']>;
 };
 
 export type AddEquipmentResponsibleMutationVariables = Exact<{
@@ -3053,7 +3199,7 @@ export type DeleteEquipmentAssignmentMutation = (
 );
 
 export type GetAvailableEquipmentsQueryVariables = Exact<{
-  scheduledEventId: Scalars['ID'];
+  scheduledEventId: Scalars['Int'];
 }>;
 
 
@@ -3066,7 +3212,7 @@ export type GetAvailableEquipmentsQuery = (
 );
 
 export type GetEquipmentQueryVariables = Exact<{
-  id: Scalars['ID'];
+  id: Scalars['Int'];
 }>;
 
 
@@ -3097,7 +3243,7 @@ export type GetEquipmentsQuery = (
 );
 
 export type UpdateEquipmentMutationVariables = Exact<{
-  id: Scalars['ID'];
+  id: Scalars['Int'];
   updateEquipmentInput: EquipmentInput;
 }>;
 
@@ -3147,7 +3293,7 @@ export type BulkUpsertLostTimesMutation = (
 );
 
 export type GetProposalBookingLostTimesQueryVariables = Exact<{
-  proposalBookingId: Scalars['ID'];
+  proposalBookingId: Scalars['Int'];
 }>;
 
 
@@ -3155,7 +3301,7 @@ export type GetProposalBookingLostTimesQuery = (
   { __typename?: 'Query' }
   & { proposalBookingLostTimes: Array<(
     { __typename?: 'LostTime' }
-    & Pick<LostTime, 'id' | 'startsAt' | 'endsAt'>
+    & Pick<LostTime, 'id' | 'startsAt' | 'scheduledEventId' | 'endsAt'>
   )> }
 );
 
@@ -3220,7 +3366,7 @@ export type ServerHealthCheckQuery = (
 );
 
 export type ActivateProposalBookingMutationVariables = Exact<{
-  id: Scalars['ID'];
+  id: Scalars['Int'];
 }>;
 
 
@@ -3234,7 +3380,7 @@ export type ActivateProposalBookingMutation = (
 
 export type FinalizeProposalBookingMutationVariables = Exact<{
   action: ProposalBookingFinalizeAction;
-  id: Scalars['ID'];
+  id: Scalars['Int'];
 }>;
 
 
@@ -3247,7 +3393,7 @@ export type FinalizeProposalBookingMutation = (
 );
 
 export type GetInstrumentProposalBookingsQueryVariables = Exact<{
-  instrumentId: Scalars['ID'];
+  instrumentId: Scalars['Int'];
   filter: ProposalBookingScheduledEventFilter;
 }>;
 
@@ -3271,7 +3417,7 @@ export type GetInstrumentProposalBookingsQuery = (
 );
 
 export type GetProposalBookingQueryVariables = Exact<{
-  id: Scalars['ID'];
+  id: Scalars['Int'];
   filter: ProposalBookingScheduledEventFilter;
 }>;
 
@@ -3366,7 +3512,7 @@ export type GetEquipmentScheduledEventsQuery = (
 );
 
 export type GetProposalBookingScheduledEventsQueryVariables = Exact<{
-  proposalBookingId: Scalars['ID'];
+  proposalBookingId: Scalars['Int'];
 }>;
 
 
@@ -3379,8 +3525,8 @@ export type GetProposalBookingScheduledEventsQuery = (
 );
 
 export type GetScheduledEventWithEquipmentsQueryVariables = Exact<{
-  proposalBookingId: Scalars['ID'];
-  scheduledEventId: Scalars['ID'];
+  proposalBookingId: Scalars['Int'];
+  scheduledEventId: Scalars['Int'];
 }>;
 
 
@@ -3388,8 +3534,22 @@ export type GetScheduledEventWithEquipmentsQuery = (
   { __typename?: 'Query' }
   & { proposalBookingScheduledEvent: Maybe<(
     { __typename?: 'ScheduledEvent' }
-    & Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt'>
-    & { equipments: Array<(
+    & Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt' | 'status'>
+    & { proposalBooking: Maybe<(
+      { __typename?: 'ProposalBooking' }
+      & Pick<ProposalBooking, 'status'>
+      & { proposal: Maybe<(
+        { __typename?: 'Proposal' }
+        & Pick<Proposal, 'primaryKey' | 'title' | 'proposalId'>
+        & { proposer: Maybe<(
+          { __typename?: 'BasicUserDetails' }
+          & Pick<BasicUserDetails, 'firstname' | 'lastname'>
+        )> }
+      )> }
+    )>, scheduledBy: Maybe<(
+      { __typename?: 'User' }
+      & Pick<User, 'firstname' | 'lastname'>
+    )>, equipments: Array<(
       { __typename?: 'EquipmentWithAssignmentStatus' }
       & Pick<EquipmentWithAssignmentStatus, 'id' | 'name' | 'maintenanceStartsAt' | 'maintenanceEndsAt' | 'status'>
     )> }
@@ -3435,7 +3595,7 @@ export type GetScheduledEventsQuery = (
 );
 
 export type GetScheduledEventsWithEquipmentsQueryVariables = Exact<{
-  proposalBookingId: Scalars['ID'];
+  proposalBookingId: Scalars['Int'];
 }>;
 
 
@@ -3531,7 +3691,7 @@ export const DeleteEquipmentAssignmentDocument = gql`
 }
     `;
 export const GetAvailableEquipmentsDocument = gql`
-    query getAvailableEquipments($scheduledEventId: ID!) {
+    query getAvailableEquipments($scheduledEventId: Int!) {
   availableEquipments(scheduledEventId: $scheduledEventId) {
     id
     createdAt
@@ -3544,7 +3704,7 @@ export const GetAvailableEquipmentsDocument = gql`
 }
     `;
 export const GetEquipmentDocument = gql`
-    query getEquipment($id: ID!) {
+    query getEquipment($id: Int!) {
   equipment(id: $id) {
     id
     createdAt
@@ -3579,7 +3739,7 @@ export const GetEquipmentsDocument = gql`
 }
     `;
 export const UpdateEquipmentDocument = gql`
-    mutation updateEquipment($id: ID!, $updateEquipmentInput: EquipmentInput!) {
+    mutation updateEquipment($id: Int!, $updateEquipmentInput: EquipmentInput!) {
   updateEquipment(id: $id, updateEquipmentInput: $updateEquipmentInput) {
     error
     equipment {
@@ -3616,10 +3776,11 @@ export const BulkUpsertLostTimesDocument = gql`
 }
     `;
 export const GetProposalBookingLostTimesDocument = gql`
-    query getProposalBookingLostTimes($proposalBookingId: ID!) {
+    query getProposalBookingLostTimes($proposalBookingId: Int!) {
   proposalBookingLostTimes(proposalBookingId: $proposalBookingId) {
     id
     startsAt
+    scheduledEventId
     endsAt
   }
 }
@@ -3663,21 +3824,21 @@ export const ServerHealthCheckDocument = gql`
 }
     `;
 export const ActivateProposalBookingDocument = gql`
-    mutation activateProposalBooking($id: ID!) {
+    mutation activateProposalBooking($id: Int!) {
   activateProposalBooking(id: $id) {
     error
   }
 }
     `;
 export const FinalizeProposalBookingDocument = gql`
-    mutation finalizeProposalBooking($action: ProposalBookingFinalizeAction!, $id: ID!) {
+    mutation finalizeProposalBooking($action: ProposalBookingFinalizeAction!, $id: Int!) {
   finalizeProposalBooking(action: $action, id: $id) {
     error
   }
 }
     `;
 export const GetInstrumentProposalBookingsDocument = gql`
-    query getInstrumentProposalBookings($instrumentId: ID!, $filter: ProposalBookingScheduledEventFilter!) {
+    query getInstrumentProposalBookings($instrumentId: Int!, $filter: ProposalBookingScheduledEventFilter!) {
   instrumentProposalBookings(instrumentId: $instrumentId) {
     id
     call {
@@ -3705,7 +3866,7 @@ export const GetInstrumentProposalBookingsDocument = gql`
 }
     `;
 export const GetProposalBookingDocument = gql`
-    query getProposalBooking($id: ID!, $filter: ProposalBookingScheduledEventFilter!) {
+    query getProposalBooking($id: Int!, $filter: ProposalBookingScheduledEventFilter!) {
   proposalBooking(id: $id) {
     id
     call {
@@ -3795,7 +3956,7 @@ export const GetEquipmentScheduledEventsDocument = gql`
 }
     `;
 export const GetProposalBookingScheduledEventsDocument = gql`
-    query getProposalBookingScheduledEvents($proposalBookingId: ID!) {
+    query getProposalBookingScheduledEvents($proposalBookingId: Int!) {
   proposalBookingScheduledEvents(proposalBookingId: $proposalBookingId) {
     id
     startsAt
@@ -3804,7 +3965,7 @@ export const GetProposalBookingScheduledEventsDocument = gql`
 }
     `;
 export const GetScheduledEventWithEquipmentsDocument = gql`
-    query getScheduledEventWithEquipments($proposalBookingId: ID!, $scheduledEventId: ID!) {
+    query getScheduledEventWithEquipments($proposalBookingId: Int!, $scheduledEventId: Int!) {
   proposalBookingScheduledEvent(
     proposalBookingId: $proposalBookingId
     scheduledEventId: $scheduledEventId
@@ -3812,6 +3973,23 @@ export const GetScheduledEventWithEquipmentsDocument = gql`
     id
     startsAt
     endsAt
+    status
+    proposalBooking {
+      status
+      proposal {
+        primaryKey
+        title
+        proposalId
+        proposer {
+          firstname
+          lastname
+        }
+      }
+    }
+    scheduledBy {
+      firstname
+      lastname
+    }
     equipments {
       id
       name
@@ -3870,7 +4048,7 @@ export const GetScheduledEventsDocument = gql`
 }
     `;
 export const GetScheduledEventsWithEquipmentsDocument = gql`
-    query getScheduledEventsWithEquipments($proposalBookingId: ID!) {
+    query getScheduledEventsWithEquipments($proposalBookingId: Int!) {
   proposalBookingScheduledEvents(proposalBookingId: $proposalBookingId) {
     id
     startsAt

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -19,6 +19,10 @@ export type Scalars = {
   TzLessDateTime: string;
 };
 
+export type ActivateScheduledEventInput = {
+  id: Scalars['Int'];
+};
+
 export type AddProposalWorkflowStatusInput = {
   proposalWorkflowId: Scalars['Int'];
   sortOrder: Scalars['Int'];
@@ -526,6 +530,11 @@ export type FileUploadConfig = {
   max_files: Scalars['Int'];
 };
 
+export type FinalizeScheduledEventInput = {
+  id: Scalars['Int'];
+  action: ProposalBookingFinalizeAction;
+};
+
 export type HealthStats = {
   __typename?: 'HealthStats';
   message: Scalars['String'];
@@ -747,6 +756,9 @@ export type Mutation = {
   bulkUpsertLostTimes: LostTimesResponseWrap;
   createScheduledEvent: ScheduledEventResponseWrap;
   bulkUpsertScheduledEvents: ScheduledEventsResponseWrap;
+  updateScheduledEvent: ScheduledEventResponseWrap;
+  activateScheduledEvent: ScheduledEventResponseWrap;
+  finalizeScheduledEvent: ScheduledEventResponseWrap;
   finalizeProposalBooking: ProposalBookingResponseWrap;
   activateProposalBooking: ProposalBookingResponseWrap;
   resetSchedulerDb: Scalars['String'];
@@ -1526,6 +1538,21 @@ export type MutationCreateScheduledEventArgs = {
 
 export type MutationBulkUpsertScheduledEventsArgs = {
   bulkUpsertScheduledEvents: BulkUpsertScheduledEventsInput;
+};
+
+
+export type MutationUpdateScheduledEventArgs = {
+  updateScheduledEvent: UpdateScheduledEventInput;
+};
+
+
+export type MutationActivateScheduledEventArgs = {
+  activateScheduledEvent: ActivateScheduledEventInput;
+};
+
+
+export type MutationFinalizeScheduledEventArgs = {
+  finalizeScheduledEvent: FinalizeScheduledEventInput;
 };
 
 
@@ -3014,6 +3041,12 @@ export type UpdateProposalWorkflowInput = {
   description: Scalars['String'];
 };
 
+export type UpdateScheduledEventInput = {
+  scheduledEventId: Scalars['Int'];
+  startsAt: Scalars['TzLessDateTime'];
+  endsAt: Scalars['TzLessDateTime'];
+};
+
 export type User = {
   __typename?: 'User';
   id: Scalars['Int'];
@@ -3440,6 +3473,23 @@ export type GetProposalBookingQuery = (
   )> }
 );
 
+export type ActivateScheduledEventMutationVariables = Exact<{
+  input: ActivateScheduledEventInput;
+}>;
+
+
+export type ActivateScheduledEventMutation = (
+  { __typename?: 'Mutation' }
+  & { activateScheduledEvent: (
+    { __typename?: 'ScheduledEventResponseWrap' }
+    & Pick<ScheduledEventResponseWrap, 'error'>
+    & { scheduledEvent: Maybe<(
+      { __typename?: 'ScheduledEvent' }
+      & Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt'>
+    )> }
+  ) }
+);
+
 export type BulkUpsertScheduledEventsMutationVariables = Exact<{
   input: BulkUpsertScheduledEventsInput;
 }>;
@@ -3474,6 +3524,19 @@ export type CreateScheduledEventMutation = (
   ) }
 );
 
+export type FinalizeScheduledEventMutationVariables = Exact<{
+  input: FinalizeScheduledEventInput;
+}>;
+
+
+export type FinalizeScheduledEventMutation = (
+  { __typename?: 'Mutation' }
+  & { finalizeScheduledEvent: (
+    { __typename?: 'ScheduledEventResponseWrap' }
+    & Pick<ScheduledEventResponseWrap, 'error'>
+  ) }
+);
+
 export type GetEquipmentScheduledEventsQueryVariables = Exact<{
   equipmentIds: Array<Scalars['Int']> | Scalars['Int'];
   endsAt: Scalars['TzLessDateTime'];
@@ -3488,7 +3551,7 @@ export type GetEquipmentScheduledEventsQuery = (
     & Pick<Equipment, 'id' | 'name'>
     & { events: Array<(
       { __typename?: 'ScheduledEvent' }
-      & Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt' | 'equipmentAssignmentStatus' | 'equipmentId'>
+      & Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt' | 'status' | 'equipmentAssignmentStatus' | 'equipmentId'>
       & { proposalBooking: Maybe<(
         { __typename?: 'ProposalBooking' }
         & Pick<ProposalBooking, 'status'>
@@ -3549,6 +3612,9 @@ export type GetScheduledEventWithEquipmentsQuery = (
           { __typename?: 'BasicUserDetails' }
           & Pick<BasicUserDetails, 'firstname' | 'lastname'>
         )> }
+      )>, call: Maybe<(
+        { __typename?: 'Call' }
+        & Pick<Call, 'id' | 'shortCode' | 'startCycle' | 'endCycle' | 'cycleComment'>
       )> }
     )>, scheduledBy: Maybe<(
       { __typename?: 'User' }
@@ -3570,7 +3636,7 @@ export type GetScheduledEventsQuery = (
   { __typename?: 'Query' }
   & { scheduledEvents: Array<(
     { __typename?: 'ScheduledEvent' }
-    & Pick<ScheduledEvent, 'id' | 'bookingType' | 'equipmentId' | 'startsAt' | 'endsAt' | 'description'>
+    & Pick<ScheduledEvent, 'id' | 'bookingType' | 'equipmentId' | 'startsAt' | 'endsAt' | 'status' | 'description'>
     & { instrument: Maybe<(
       { __typename?: 'Instrument' }
       & Pick<Instrument, 'name'>
@@ -3607,12 +3673,29 @@ export type GetScheduledEventsWithEquipmentsQuery = (
   { __typename?: 'Query' }
   & { proposalBookingScheduledEvents: Array<(
     { __typename?: 'ScheduledEvent' }
-    & Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt'>
+    & Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt' | 'status'>
     & { equipments: Array<(
       { __typename?: 'EquipmentWithAssignmentStatus' }
       & Pick<EquipmentWithAssignmentStatus, 'id' | 'name' | 'maintenanceStartsAt' | 'maintenanceEndsAt' | 'status'>
     )> }
   )> }
+);
+
+export type UpdateScheduledEventMutationVariables = Exact<{
+  input: UpdateScheduledEventInput;
+}>;
+
+
+export type UpdateScheduledEventMutation = (
+  { __typename?: 'Mutation' }
+  & { updateScheduledEvent: (
+    { __typename?: 'ScheduledEventResponseWrap' }
+    & Pick<ScheduledEventResponseWrap, 'error'>
+    & { scheduledEvent: Maybe<(
+      { __typename?: 'ScheduledEvent' }
+      & Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt'>
+    )> }
+  ) }
 );
 
 export type BasicUserDetailsFragment = (
@@ -3897,6 +3980,18 @@ export const GetProposalBookingDocument = gql`
   }
 }
     `;
+export const ActivateScheduledEventDocument = gql`
+    mutation activateScheduledEvent($input: ActivateScheduledEventInput!) {
+  activateScheduledEvent(activateScheduledEvent: $input) {
+    error
+    scheduledEvent {
+      id
+      startsAt
+      endsAt
+    }
+  }
+}
+    `;
 export const BulkUpsertScheduledEventsDocument = gql`
     mutation bulkUpsertScheduledEvents($input: BulkUpsertScheduledEventsInput!) {
   bulkUpsertScheduledEvents(bulkUpsertScheduledEvents: $input) {
@@ -3923,6 +4018,13 @@ export const CreateScheduledEventDocument = gql`
   }
 }
     `;
+export const FinalizeScheduledEventDocument = gql`
+    mutation finalizeScheduledEvent($input: FinalizeScheduledEventInput!) {
+  finalizeScheduledEvent(finalizeScheduledEvent: $input) {
+    error
+  }
+}
+    `;
 export const GetEquipmentScheduledEventsDocument = gql`
     query getEquipmentScheduledEvents($equipmentIds: [Int!]!, $endsAt: TzLessDateTime!, $startsAt: TzLessDateTime!) {
   equipments(equipmentIds: $equipmentIds) {
@@ -3932,6 +4034,7 @@ export const GetEquipmentScheduledEventsDocument = gql`
       id
       startsAt
       endsAt
+      status
       equipmentAssignmentStatus
       equipmentId
       proposalBooking {
@@ -3996,6 +4099,13 @@ export const GetScheduledEventWithEquipmentsDocument = gql`
           lastname
         }
       }
+      call {
+        id
+        shortCode
+        startCycle
+        endCycle
+        cycleComment
+      }
     }
     scheduledBy {
       firstname
@@ -4019,6 +4129,7 @@ export const GetScheduledEventsDocument = gql`
     equipmentId
     startsAt
     endsAt
+    status
     description
     instrument {
       name
@@ -4064,12 +4175,25 @@ export const GetScheduledEventsWithEquipmentsDocument = gql`
     id
     startsAt
     endsAt
+    status
     equipments {
       id
       name
       maintenanceStartsAt
       maintenanceEndsAt
       status
+    }
+  }
+}
+    `;
+export const UpdateScheduledEventDocument = gql`
+    mutation updateScheduledEvent($input: UpdateScheduledEventInput!) {
+  updateScheduledEvent(updateScheduledEvent: $input) {
+    error
+    scheduledEvent {
+      id
+      startsAt
+      endsAt
     }
   }
 }
@@ -4157,11 +4281,17 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     getProposalBooking(variables: GetProposalBookingQueryVariables): Promise<GetProposalBookingQuery> {
       return withWrapper(() => client.request<GetProposalBookingQuery>(print(GetProposalBookingDocument), variables));
     },
+    activateScheduledEvent(variables: ActivateScheduledEventMutationVariables): Promise<ActivateScheduledEventMutation> {
+      return withWrapper(() => client.request<ActivateScheduledEventMutation>(print(ActivateScheduledEventDocument), variables));
+    },
     bulkUpsertScheduledEvents(variables: BulkUpsertScheduledEventsMutationVariables): Promise<BulkUpsertScheduledEventsMutation> {
       return withWrapper(() => client.request<BulkUpsertScheduledEventsMutation>(print(BulkUpsertScheduledEventsDocument), variables));
     },
     createScheduledEvent(variables: CreateScheduledEventMutationVariables): Promise<CreateScheduledEventMutation> {
       return withWrapper(() => client.request<CreateScheduledEventMutation>(print(CreateScheduledEventDocument), variables));
+    },
+    finalizeScheduledEvent(variables: FinalizeScheduledEventMutationVariables): Promise<FinalizeScheduledEventMutation> {
+      return withWrapper(() => client.request<FinalizeScheduledEventMutation>(print(FinalizeScheduledEventDocument), variables));
     },
     getEquipmentScheduledEvents(variables: GetEquipmentScheduledEventsQueryVariables): Promise<GetEquipmentScheduledEventsQuery> {
       return withWrapper(() => client.request<GetEquipmentScheduledEventsQuery>(print(GetEquipmentScheduledEventsDocument), variables));
@@ -4177,6 +4307,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     getScheduledEventsWithEquipments(variables: GetScheduledEventsWithEquipmentsQueryVariables): Promise<GetScheduledEventsWithEquipmentsQuery> {
       return withWrapper(() => client.request<GetScheduledEventsWithEquipmentsQuery>(print(GetScheduledEventsWithEquipmentsDocument), variables));
+    },
+    updateScheduledEvent(variables: UpdateScheduledEventMutationVariables): Promise<UpdateScheduledEventMutation> {
+      return withWrapper(() => client.request<UpdateScheduledEventMutation>(print(UpdateScheduledEventDocument), variables));
     },
     getUsers(variables?: GetUsersQueryVariables): Promise<GetUsersQuery> {
       return withWrapper(() => client.request<GetUsersQuery>(print(GetUsersDocument), variables));

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -2346,6 +2346,7 @@ export type QueryEquipmentArgs = {
 
 
 export type QueryProposalBookingLostTimesArgs = {
+  scheduledEventId?: Maybe<Scalars['Int']>;
   proposalBookingId: Scalars['Int'];
 };
 
@@ -2822,7 +2823,7 @@ export type SimpleLostTimeInput = {
   startsAt: Scalars['TzLessDateTime'];
   endsAt: Scalars['TzLessDateTime'];
   newlyCreated?: Maybe<Scalars['Boolean']>;
-  scheduledEventId: Scalars['Int'];
+  scheduledEventId?: Maybe<Scalars['Int']>;
 };
 
 export type SimpleScheduledEventInput = {
@@ -3327,6 +3328,7 @@ export type BulkUpsertLostTimesMutation = (
 
 export type GetProposalBookingLostTimesQueryVariables = Exact<{
   proposalBookingId: Scalars['Int'];
+  scheduledEventId?: Maybe<Scalars['Int']>;
 }>;
 
 
@@ -3584,6 +3586,23 @@ export type GetProposalBookingScheduledEventsQuery = (
   & { proposalBookingScheduledEvents: Array<(
     { __typename?: 'ScheduledEvent' }
     & Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt'>
+  )> }
+);
+
+export type GetScheduledEventEquipmentsQueryVariables = Exact<{
+  proposalBookingId: Scalars['Int'];
+  scheduledEventId: Scalars['Int'];
+}>;
+
+
+export type GetScheduledEventEquipmentsQuery = (
+  { __typename?: 'Query' }
+  & { proposalBookingScheduledEvent: Maybe<(
+    { __typename?: 'ScheduledEvent' }
+    & { equipments: Array<(
+      { __typename?: 'EquipmentWithAssignmentStatus' }
+      & Pick<EquipmentWithAssignmentStatus, 'id' | 'name' | 'maintenanceStartsAt' | 'maintenanceEndsAt' | 'status'>
+    )> }
   )> }
 );
 
@@ -3863,8 +3882,11 @@ export const BulkUpsertLostTimesDocument = gql`
 }
     `;
 export const GetProposalBookingLostTimesDocument = gql`
-    query getProposalBookingLostTimes($proposalBookingId: Int!) {
-  proposalBookingLostTimes(proposalBookingId: $proposalBookingId) {
+    query getProposalBookingLostTimes($proposalBookingId: Int!, $scheduledEventId: Int) {
+  proposalBookingLostTimes(
+    proposalBookingId: $proposalBookingId
+    scheduledEventId: $scheduledEventId
+  ) {
     id
     startsAt
     scheduledEventId
@@ -4068,6 +4090,22 @@ export const GetProposalBookingScheduledEventsDocument = gql`
     id
     startsAt
     endsAt
+  }
+}
+    `;
+export const GetScheduledEventEquipmentsDocument = gql`
+    query getScheduledEventEquipments($proposalBookingId: Int!, $scheduledEventId: Int!) {
+  proposalBookingScheduledEvent(
+    proposalBookingId: $proposalBookingId
+    scheduledEventId: $scheduledEventId
+  ) {
+    equipments {
+      id
+      name
+      maintenanceStartsAt
+      maintenanceEndsAt
+      status
+    }
   }
 }
     `;
@@ -4298,6 +4336,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     getProposalBookingScheduledEvents(variables: GetProposalBookingScheduledEventsQueryVariables): Promise<GetProposalBookingScheduledEventsQuery> {
       return withWrapper(() => client.request<GetProposalBookingScheduledEventsQuery>(print(GetProposalBookingScheduledEventsDocument), variables));
+    },
+    getScheduledEventEquipments(variables: GetScheduledEventEquipmentsQueryVariables): Promise<GetScheduledEventEquipmentsQuery> {
+      return withWrapper(() => client.request<GetScheduledEventEquipmentsQuery>(print(GetScheduledEventEquipmentsDocument), variables));
     },
     getScheduledEventWithEquipments(variables: GetScheduledEventWithEquipmentsQueryVariables): Promise<GetScheduledEventWithEquipmentsQuery> {
       return withWrapper(() => client.request<GetScheduledEventWithEquipmentsQuery>(print(GetScheduledEventWithEquipmentsDocument), variables));

--- a/src/graphql/equipment/getAvailableEquipments.graphql
+++ b/src/graphql/equipment/getAvailableEquipments.graphql
@@ -1,4 +1,4 @@
-query getAvailableEquipments($scheduledEventId: ID!) {
+query getAvailableEquipments($scheduledEventId: Int!) {
   availableEquipments(scheduledEventId: $scheduledEventId) {
     id
     createdAt

--- a/src/graphql/equipment/getEquipment.graphql
+++ b/src/graphql/equipment/getEquipment.graphql
@@ -1,4 +1,4 @@
-query getEquipment($id: ID!) {
+query getEquipment($id: Int!) {
   equipment(id: $id) {
     id
     createdAt

--- a/src/graphql/equipment/updateEquipment.graphql
+++ b/src/graphql/equipment/updateEquipment.graphql
@@ -1,4 +1,4 @@
-mutation updateEquipment($id: ID!, $updateEquipmentInput: EquipmentInput!) {
+mutation updateEquipment($id: Int!, $updateEquipmentInput: EquipmentInput!) {
   updateEquipment(id: $id, updateEquipmentInput: $updateEquipmentInput) {
     error
     equipment {

--- a/src/graphql/lostTime/getProposalBookingLostTimes.graphql
+++ b/src/graphql/lostTime/getProposalBookingLostTimes.graphql
@@ -1,5 +1,11 @@
-query getProposalBookingLostTimes($proposalBookingId: Int!) {
-  proposalBookingLostTimes(proposalBookingId: $proposalBookingId) {
+query getProposalBookingLostTimes(
+  $proposalBookingId: Int!
+  $scheduledEventId: Int
+) {
+  proposalBookingLostTimes(
+    proposalBookingId: $proposalBookingId
+    scheduledEventId: $scheduledEventId
+  ) {
     id
     startsAt
     scheduledEventId

--- a/src/graphql/lostTime/getProposalBookingLostTimes.graphql
+++ b/src/graphql/lostTime/getProposalBookingLostTimes.graphql
@@ -1,7 +1,8 @@
-query getProposalBookingLostTimes($proposalBookingId: ID!) {
+query getProposalBookingLostTimes($proposalBookingId: Int!) {
   proposalBookingLostTimes(proposalBookingId: $proposalBookingId) {
     id
     startsAt
+    scheduledEventId
     endsAt
   }
 }

--- a/src/graphql/proposalBooking/activateProposalBooking.graphql
+++ b/src/graphql/proposalBooking/activateProposalBooking.graphql
@@ -1,4 +1,4 @@
-mutation activateProposalBooking($id: ID!) {
+mutation activateProposalBooking($id: Int!) {
   activateProposalBooking(id: $id) {
     error
   }

--- a/src/graphql/proposalBooking/finalizeProposalBooking.graphql
+++ b/src/graphql/proposalBooking/finalizeProposalBooking.graphql
@@ -1,6 +1,6 @@
 mutation finalizeProposalBooking(
   $action: ProposalBookingFinalizeAction!
-  $id: ID!
+  $id: Int!
 ) {
   finalizeProposalBooking(action: $action, id: $id) {
     error

--- a/src/graphql/proposalBooking/getInstrumentProposalBookings.graphql
+++ b/src/graphql/proposalBooking/getInstrumentProposalBookings.graphql
@@ -1,5 +1,5 @@
 query getInstrumentProposalBookings(
-  $instrumentId: ID!
+  $instrumentId: Int!
   $filter: ProposalBookingScheduledEventFilter!
 ) {
   instrumentProposalBookings(instrumentId: $instrumentId) {

--- a/src/graphql/proposalBooking/getProposalBooking.graphql
+++ b/src/graphql/proposalBooking/getProposalBooking.graphql
@@ -1,5 +1,5 @@
 query getProposalBooking(
-  $id: ID!
+  $id: Int!
   $filter: ProposalBookingScheduledEventFilter!
 ) {
   proposalBooking(id: $id) {

--- a/src/graphql/scheduledEvent/activateScheduledEvent.graphql
+++ b/src/graphql/scheduledEvent/activateScheduledEvent.graphql
@@ -1,0 +1,10 @@
+mutation activateScheduledEvent($input: ActivateScheduledEventInput!) {
+  activateScheduledEvent(activateScheduledEvent: $input) {
+    error
+    scheduledEvent {
+      id
+      startsAt
+      endsAt
+    }
+  }
+}

--- a/src/graphql/scheduledEvent/finalizeScheduledEvent.graphql
+++ b/src/graphql/scheduledEvent/finalizeScheduledEvent.graphql
@@ -1,0 +1,5 @@
+mutation finalizeScheduledEvent($input: FinalizeScheduledEventInput!) {
+  finalizeScheduledEvent(finalizeScheduledEvent: $input) {
+    error
+  }
+}

--- a/src/graphql/scheduledEvent/getEquipmentScheduledEvents.graphql
+++ b/src/graphql/scheduledEvent/getEquipmentScheduledEvents.graphql
@@ -10,6 +10,7 @@ query getEquipmentScheduledEvents(
       id
       startsAt
       endsAt
+      status
       equipmentAssignmentStatus
       equipmentId
       proposalBooking {

--- a/src/graphql/scheduledEvent/getProposalBookingScheduledEvents.graphql
+++ b/src/graphql/scheduledEvent/getProposalBookingScheduledEvents.graphql
@@ -1,4 +1,4 @@
-query getProposalBookingScheduledEvents($proposalBookingId: ID!) {
+query getProposalBookingScheduledEvents($proposalBookingId: Int!) {
   proposalBookingScheduledEvents(proposalBookingId: $proposalBookingId) {
     id
     startsAt

--- a/src/graphql/scheduledEvent/getScheduledEventEquipments.graphql
+++ b/src/graphql/scheduledEvent/getScheduledEventEquipments.graphql
@@ -1,0 +1,17 @@
+query getScheduledEventEquipments(
+  $proposalBookingId: Int!
+  $scheduledEventId: Int!
+) {
+  proposalBookingScheduledEvent(
+    proposalBookingId: $proposalBookingId
+    scheduledEventId: $scheduledEventId
+  ) {
+    equipments {
+      id
+      name
+      maintenanceStartsAt
+      maintenanceEndsAt
+      status
+    }
+  }
+}

--- a/src/graphql/scheduledEvent/getScheduledEventWithEquipments.graphql
+++ b/src/graphql/scheduledEvent/getScheduledEventWithEquipments.graphql
@@ -1,6 +1,6 @@
 query getScheduledEventWithEquipments(
-  $proposalBookingId: ID!
-  $scheduledEventId: ID!
+  $proposalBookingId: Int!
+  $scheduledEventId: Int!
 ) {
   proposalBookingScheduledEvent(
     proposalBookingId: $proposalBookingId
@@ -9,6 +9,23 @@ query getScheduledEventWithEquipments(
     id
     startsAt
     endsAt
+    status
+    proposalBooking {
+      status
+      proposal {
+        primaryKey
+        title
+        proposalId
+        proposer {
+          firstname
+          lastname
+        }
+      }
+    }
+    scheduledBy {
+      firstname
+      lastname
+    }
     equipments {
       id
       name

--- a/src/graphql/scheduledEvent/getScheduledEventWithEquipments.graphql
+++ b/src/graphql/scheduledEvent/getScheduledEventWithEquipments.graphql
@@ -29,6 +29,13 @@ query getScheduledEventWithEquipments(
           lastname
         }
       }
+      call {
+        id
+        shortCode
+        startCycle
+        endCycle
+        cycleComment
+      }
     }
     scheduledBy {
       firstname

--- a/src/graphql/scheduledEvent/getScheduledEventWithEquipments.graphql
+++ b/src/graphql/scheduledEvent/getScheduledEventWithEquipments.graphql
@@ -1,6 +1,7 @@
 query getScheduledEventWithEquipments(
   $proposalBookingId: Int!
   $scheduledEventId: Int!
+  $scheduledEventFilter: ProposalBookingScheduledEventFilter!
 ) {
   proposalBookingScheduledEvent(
     proposalBookingId: $proposalBookingId
@@ -11,7 +12,14 @@ query getScheduledEventWithEquipments(
     endsAt
     status
     proposalBooking {
+      id
       status
+      allocatedTime
+      scheduledEvents(filter: $scheduledEventFilter) {
+        id
+        startsAt
+        endsAt
+      }
       proposal {
         primaryKey
         title

--- a/src/graphql/scheduledEvent/getScheduledEvents.graphql
+++ b/src/graphql/scheduledEvent/getScheduledEvents.graphql
@@ -8,6 +8,7 @@ query getScheduledEvents(
     equipmentId
     startsAt
     endsAt
+    status
     description
     instrument {
       name

--- a/src/graphql/scheduledEvent/getScheduledEventsWithEquipments.graphql
+++ b/src/graphql/scheduledEvent/getScheduledEventsWithEquipments.graphql
@@ -3,6 +3,7 @@ query getScheduledEventsWithEquipments($proposalBookingId: Int!) {
     id
     startsAt
     endsAt
+    status
     equipments {
       id
       name

--- a/src/graphql/scheduledEvent/getScheduledEventsWithEquipments.graphql
+++ b/src/graphql/scheduledEvent/getScheduledEventsWithEquipments.graphql
@@ -1,4 +1,4 @@
-query getScheduledEventsWithEquipments($proposalBookingId: ID!) {
+query getScheduledEventsWithEquipments($proposalBookingId: Int!) {
   proposalBookingScheduledEvents(proposalBookingId: $proposalBookingId) {
     id
     startsAt

--- a/src/graphql/scheduledEvent/updateScheduledEvent.graphql
+++ b/src/graphql/scheduledEvent/updateScheduledEvent.graphql
@@ -1,0 +1,10 @@
+mutation updateScheduledEvent($input: UpdateScheduledEventInput!) {
+  updateScheduledEvent(updateScheduledEvent: $input) {
+    error
+    scheduledEvent {
+      id
+      startsAt
+      endsAt
+    }
+  }
+}

--- a/src/hooks/equipment/useAvailableEquipments.ts
+++ b/src/hooks/equipment/useAvailableEquipments.ts
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react';
 import { Equipment } from 'generated/sdk';
 import { useDataApi } from 'hooks/common/useDataApi';
 
-export default function useAvailableEquipments(scheduledEventId: string) {
+export default function useAvailableEquipments(scheduledEventId: number) {
   const [loading, setLoading] = useState(true);
   const [equipments, setEquipments] = useState<
     Pick<

--- a/src/hooks/equipment/useEquipment.ts
+++ b/src/hooks/equipment/useEquipment.ts
@@ -17,7 +17,7 @@ export type DetailedEquipment = Pick<
   equipmentResponsible: Array<Pick<User, 'id' | 'firstname' | 'lastname'>>;
 };
 
-export default function useEquipment(id?: string) {
+export default function useEquipment(id?: number) {
   const [loading, setLoading] = useState(true);
   const [equipment, setEquipment] = useState<DetailedEquipment | null>(null);
 

--- a/src/hooks/equipment/useEquipment.ts
+++ b/src/hooks/equipment/useEquipment.ts
@@ -25,7 +25,7 @@ export default function useEquipment(id?: number) {
 
   useEffect(() => {
     let unmount = false;
-    if (id) {
+    if (id !== undefined) {
       setLoading(true);
       api()
         .getEquipment({ id })

--- a/src/hooks/lostTime/useProposalBookingLostTimes.ts
+++ b/src/hooks/lostTime/useProposalBookingLostTimes.ts
@@ -5,10 +5,10 @@ import { useDataApi } from 'hooks/common/useDataApi';
 
 export type ProposalBookingLostTime = Pick<
   LostTime,
-  'id' | 'startsAt' | 'endsAt'
+  'id' | 'startsAt' | 'endsAt' | 'scheduledEventId'
 >;
 
-export default function useProposalBookingLostTimes(proposalBookingId: string) {
+export default function useProposalBookingLostTimes(proposalBookingId: number) {
   const [loading, setLoading] = useState(true);
   const [lostTimes, setLostTimes] = useState<ProposalBookingLostTime[]>([]);
 

--- a/src/hooks/lostTime/useProposalBookingLostTimes.ts
+++ b/src/hooks/lostTime/useProposalBookingLostTimes.ts
@@ -8,7 +8,10 @@ export type ProposalBookingLostTime = Pick<
   'id' | 'startsAt' | 'endsAt' | 'scheduledEventId'
 >;
 
-export default function useProposalBookingLostTimes(proposalBookingId: number) {
+export default function useProposalBookingLostTimes(
+  proposalBookingId: number,
+  scheduledEventId?: number
+) {
   const [loading, setLoading] = useState(true);
   const [lostTimes, setLostTimes] = useState<ProposalBookingLostTime[]>([]);
 
@@ -19,7 +22,7 @@ export default function useProposalBookingLostTimes(proposalBookingId: number) {
 
     setLoading(true);
     api()
-      .getProposalBookingLostTimes({ proposalBookingId })
+      .getProposalBookingLostTimes({ proposalBookingId, scheduledEventId })
       .then((data) => {
         if (unmount) {
           return;
@@ -36,7 +39,7 @@ export default function useProposalBookingLostTimes(proposalBookingId: number) {
     return () => {
       unmount = true;
     };
-  }, [proposalBookingId, api]);
+  }, [proposalBookingId, scheduledEventId, api]);
 
   return { loading, lostTimes } as const;
 }

--- a/src/hooks/proposalBooking/useInstrumentProposalBookings.ts
+++ b/src/hooks/proposalBooking/useInstrumentProposalBookings.ts
@@ -21,7 +21,7 @@ export type InstrumentProposalBooking = Pick<
 };
 
 export default function useInstrumentProposalBookings(
-  instrumentId: string | null
+  instrumentId: number | null
 ) {
   const [loading, setLoading] = useState(false);
   const [proposalBookings, setProposalBookings] = useState<

--- a/src/hooks/proposalBooking/useProposalBooking.ts
+++ b/src/hooks/proposalBooking/useProposalBooking.ts
@@ -20,7 +20,7 @@ export type DetailedProposalBooking = Pick<
   proposal: Pick<Proposal, 'primaryKey' | 'title' | 'proposalId'>;
 };
 
-export default function useProposalBooking(id: string) {
+export default function useProposalBooking(id: number) {
   const [loading, setLoading] = useState(true);
   const [proposalBooking, setProposalBooking] =
     useState<DetailedProposalBooking | null>(null);

--- a/src/hooks/scheduledEvent/useEquipmentScheduledEvents.ts
+++ b/src/hooks/scheduledEvent/useEquipmentScheduledEvents.ts
@@ -10,14 +10,14 @@ export default function useEquipmentScheduledEvents({
 }: {
   startsAt: Scalars['TzLessDateTime'];
   endsAt: Scalars['TzLessDateTime'];
-  equipmentIds?: string[];
+  equipmentIds?: number[];
 }) {
   const [loading, setLoading] = useState(true);
   const [scheduledEvents, setScheduledEvents] = useState<
     GetEquipmentScheduledEventsQuery['equipments']
   >([]);
   const equipmentIdsArray = equipmentIds?.flatMap((equipmentId) =>
-    equipmentId ? [parseInt(equipmentId)] : []
+    equipmentId ? [equipmentId] : []
   );
 
   const [selectedEquipment, setSelectedEquipments] = useState<

--- a/src/hooks/scheduledEvent/useProposalBookingScheduledEvents.ts
+++ b/src/hooks/scheduledEvent/useProposalBookingScheduledEvents.ts
@@ -9,7 +9,7 @@ export type ProposalBookingScheduledEvent = Pick<
 >;
 
 export default function useProposalBookingScheduledEvents(
-  proposalBookingId: string
+  proposalBookingId: number
 ) {
   const [loading, setLoading] = useState(true);
   const [scheduledEvents, setScheduledEvents] = useState<

--- a/src/hooks/scheduledEvent/useScheduledEventEquipments.ts
+++ b/src/hooks/scheduledEvent/useScheduledEventEquipments.ts
@@ -1,0 +1,52 @@
+import { useState, useEffect, useCallback } from 'react';
+
+import { useDataApi } from 'hooks/common/useDataApi';
+
+import { ScheduledEventEquipment } from './useScheduledEventWithEquipment';
+
+export default function useScheduledEventEquipments({
+  proposalBookingId,
+  scheduledEventId,
+}: {
+  proposalBookingId: number;
+  scheduledEventId: number;
+}) {
+  const [loading, setLoading] = useState(true);
+  const [equipments, setEquipments] = useState<ScheduledEventEquipment[]>([]);
+
+  // may look stupid, but basically lets us provide a refresh option
+  // and we won't get a warning when the component gets unmounted while
+  // the promise still pending
+  const [counter, setCounter] = useState<number>(0);
+
+  const api = useDataApi();
+
+  const refresh = useCallback(() => {
+    setCounter((prev) => prev + 1);
+  }, [setCounter]);
+
+  useEffect(() => {
+    let unmount = false;
+
+    setLoading(true);
+    api()
+      .getScheduledEventEquipments({ proposalBookingId, scheduledEventId })
+      .then((data) => {
+        if (unmount) {
+          return;
+        }
+
+        if (data.proposalBookingScheduledEvent?.equipments) {
+          setEquipments(data.proposalBookingScheduledEvent.equipments);
+        }
+
+        setLoading(false);
+      });
+
+    return () => {
+      unmount = true;
+    };
+  }, [counter, scheduledEventId, proposalBookingId, api]);
+
+  return { loading, equipments, refresh } as const;
+}

--- a/src/hooks/scheduledEvent/useScheduledEventWithEquipment.ts
+++ b/src/hooks/scheduledEvent/useScheduledEventWithEquipment.ts
@@ -10,7 +10,7 @@ export type ScheduledEventEquipment = Pick<
 
 export type ScheduledEventWithEquipments = Pick<
   ScheduledEvent,
-  'id' | 'startsAt' | 'endsAt'
+  'id' | 'startsAt' | 'endsAt' | 'status'
 > & {
   equipments: ScheduledEventEquipment[];
 };
@@ -19,8 +19,8 @@ export default function useScheduledEventWithEquipments({
   proposalBookingId,
   scheduledEventId,
 }: {
-  proposalBookingId: string;
-  scheduledEventId: string;
+  proposalBookingId: number;
+  scheduledEventId: number;
 }) {
   const [loading, setLoading] = useState(true);
   const [scheduledEvent, setScheduledEvent] =

--- a/src/hooks/scheduledEvent/useScheduledEventWithEquipment.ts
+++ b/src/hooks/scheduledEvent/useScheduledEventWithEquipment.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 
 import { ScheduledEvent, EquipmentWithAssignmentStatus } from 'generated/sdk';
 import { useDataApi } from 'hooks/common/useDataApi';
@@ -23,10 +23,15 @@ export default function useScheduledEventWithEquipments({
   scheduledEventId: number;
 }) {
   const [loading, setLoading] = useState(true);
+  const [counter, setCounter] = useState(0);
   const [scheduledEvent, setScheduledEvent] =
     useState<ScheduledEventWithEquipments | null>(null);
 
   const api = useDataApi();
+
+  const refresh = useCallback(() => {
+    setCounter((prev) => prev + 1);
+  }, [setCounter]);
 
   useEffect(() => {
     let unmount = false;
@@ -56,7 +61,7 @@ export default function useScheduledEventWithEquipments({
     return () => {
       unmount = true;
     };
-  }, [proposalBookingId, scheduledEventId, api]);
+  }, [proposalBookingId, scheduledEventId, api, counter]);
 
-  return { loading, scheduledEvent, setScheduledEvent } as const;
+  return { loading, scheduledEvent, setScheduledEvent, refresh } as const;
 }

--- a/src/hooks/scheduledEvent/useScheduledEventWithEquipment.ts
+++ b/src/hooks/scheduledEvent/useScheduledEventWithEquipment.ts
@@ -10,7 +10,7 @@ export type ScheduledEventEquipment = Pick<
 
 export type ScheduledEventWithEquipments = Pick<
   ScheduledEvent,
-  'id' | 'startsAt' | 'endsAt' | 'status'
+  'id' | 'startsAt' | 'endsAt' | 'status' | 'scheduledBy' | 'proposalBooking'
 > & {
   equipments: ScheduledEventEquipment[];
 };
@@ -33,14 +33,20 @@ export default function useScheduledEventWithEquipments({
 
     setLoading(true);
     api()
-      .getScheduledEventWithEquipments({ proposalBookingId, scheduledEventId })
+      .getScheduledEventWithEquipments({
+        proposalBookingId,
+        scheduledEventId,
+        scheduledEventFilter: {},
+      })
       .then((data) => {
         if (unmount) {
           return;
         }
 
         if (data.proposalBookingScheduledEvent) {
-          setScheduledEvent(data.proposalBookingScheduledEvent);
+          setScheduledEvent(
+            data.proposalBookingScheduledEvent as ScheduledEventWithEquipments
+          );
         }
 
         setLoading(false);
@@ -52,5 +58,5 @@ export default function useScheduledEventWithEquipments({
     };
   }, [proposalBookingId, scheduledEventId, api]);
 
-  return { loading, scheduledEvent } as const;
+  return { loading, scheduledEvent, setScheduledEvent } as const;
 }

--- a/src/hooks/scheduledEvent/useScheduledEventsWithEquipments.ts
+++ b/src/hooks/scheduledEvent/useScheduledEventsWithEquipments.ts
@@ -16,7 +16,7 @@ export type ScheduledEventWithEquipments = Pick<
 };
 
 export default function useScheduledEventsWithEquipments(
-  proposalBookingId: string
+  proposalBookingId: number
 ) {
   const [loading, setLoading] = useState(true);
   const [scheduledEvents, setScheduledEvents] = useState<

--- a/src/utils/scheduledEvent.ts
+++ b/src/utils/scheduledEvent.ts
@@ -1,6 +1,6 @@
 import { Moment } from 'moment';
 
-type BaseEvent = { id: string; startsAt: Moment | Date; endsAt: Moment | Date };
+type BaseEvent = { id: number; startsAt: Moment | Date; endsAt: Moment | Date };
 
 export function isOverlapping<T extends BaseEvent>(eventA: T, eventB: T) {
   if (


### PR DESCRIPTION
## Description

Instead of booking a time slots only grouped together as a proposal booking now the whole process of updating and managing a time slot is separated one from another. You can manage a time slot on its own book equipment save lost times restart or close per scheduled event.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

- e2e tests
- manual tests

## Fixes

https://jira.esss.lu.se/browse/SWAP-1688

## Depends on

https://github.com/UserOfficeProject/user-office-scheduler-backend/pull/63


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
