### PR TITLE
Swap 1766 time slot editing icon

### DIFF
--- a/cypress/integration/proposal-booking.spec.ts
+++ b/cypress/integration/proposal-booking.spec.ts
@@ -98,6 +98,7 @@ context('Proposal booking tests ', () => {
 
     describe('Book events step', () => {
       it('should be able to add new time slot', () => {
+        cy.contains('Proposal ID');
         cy.get('[title="Add time slot"]').click();
 
         cy.contains(currentHourDateTime);
@@ -193,6 +194,7 @@ context('Proposal booking tests ', () => {
         cy.contains(getHourDateTimeAfter(3));
 
         cy.contains('Proposal title');
+        cy.contains('Proposal ID');
         cy.get('[data-cy="btn-next"]').should('exist');
       });
 
@@ -741,6 +743,17 @@ context('Proposal booking tests ', () => {
 
       it('Completed events should have gray color and opacity', () => {
         cy.get('[data-cy="btn-close-dialog"]').click();
+
+        cy.get('[data-cy="proposal-event-Test proposal-999999"]').should(
+          'contain.text',
+          '[Completed]'
+        );
+
+        cy.get(
+          '#instrument-calls-tree-view [role=treeitem] [role=group] [role=treeitem]'
+        )
+          .first()
+          .should('contain.text', '[Completed]');
 
         cy.get('[data-cy="proposal-event-Test proposal-999999"]')
           .parent()

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -30,7 +30,10 @@ import EquipmentBookingDialog from 'components/equipment/EquipmentBookingDialog'
 import ScheduledEventDialog, {
   SlotInfo,
 } from 'components/scheduledEvent/ScheduledEventDialog';
-import { BookingTypesMap } from 'components/scheduledEvent/ScheduledEventForm';
+import {
+  BookingTypesMap,
+  ScheduledEventStatusMap,
+} from 'components/scheduledEvent/ScheduledEventForm';
 import TimeSlotBookingDialog from 'components/timeSlotBooking/TimeSlotBookingDialog';
 import { AppContext } from 'context/AppContext';
 import {
@@ -90,6 +93,7 @@ const transformEvent = (
     instrument: scheduledEvent.instrument,
     scheduledBy: scheduledEvent.scheduledBy,
     status: scheduledEvent.status,
+    statusTableRenderValue: ScheduledEventStatusMap[scheduledEvent.status],
   }));
 
 function isOverlapping(
@@ -434,7 +438,7 @@ export default function Calendar() {
       field: 'endTableRenderValue',
     },
     { title: 'Description', field: 'description' },
-    { title: 'Status', field: 'status' },
+    { title: 'Status', field: 'statusTableRenderValue' },
     { title: 'Instrument', field: 'instrument.name' },
     { title: 'Proposal', field: 'proposalBooking.proposal.title' },
     { title: 'Proposal ID', field: 'proposalBooking.proposal.proposalId' },

--- a/src/components/common/icons/IdentifierIcon.tsx
+++ b/src/components/common/icons/IdentifierIcon.tsx
@@ -1,0 +1,16 @@
+import SvgIcon from '@material-ui/core/SvgIcon';
+import React from 'react';
+
+// NOTE: The icon is taken from: https://materialdesignicons.com/
+const IdentifierIcon: React.FC = (props) => {
+  return (
+    <SvgIcon {...props}>
+      <path
+        fill="currentColor"
+        d="M10 7V9H9V15H10V17H6V15H7V9H6V7H10M16 7C17.11 7 18 7.9 18 9V15C18 16.11 17.11 17 16 17H12V7M16 9H14V15H16V9Z"
+      />
+    </SvgIcon>
+  );
+};
+
+export default IdentifierIcon;

--- a/src/components/proposalBooking/ProposalBookingDialog.tsx
+++ b/src/components/proposalBooking/ProposalBookingDialog.tsx
@@ -77,6 +77,7 @@ const getActiveStepByStatus = (
 ): number => {
   switch (status) {
     case ProposalBookingStatus.DRAFT:
+    case ProposalBookingStatus.ACTIVE:
       return ProposalBookingSteps.BOOK_EVENTS;
     case ProposalBookingStatus.COMPLETED:
       return ProposalBookingSteps.COMPLETED;

--- a/src/components/proposalBooking/ProposalBookingInfo.tsx
+++ b/src/components/proposalBooking/ProposalBookingInfo.tsx
@@ -1,11 +1,8 @@
 import { makeStyles } from '@material-ui/core';
 import React from 'react';
 
-import {
-  BasicProposalBooking,
-  isDraftEvent,
-  isCompletedEvent,
-} from 'components/calendar/Event';
+import { BasicProposalBooking } from 'components/calendar/Event';
+import { ScheduledEventStatusMap } from 'components/scheduledEvent/ScheduledEventForm';
 import { ProposalBookingStatus } from 'generated/sdk';
 
 const useStyles = makeStyles(() => ({
@@ -55,10 +52,7 @@ function ProposalBookingInfo({
       data-cy={`proposal-event-${proposal.title}-${proposal.proposalId}`}
     >
       <div className={classes.proposalId}>
-        {isDraftEvent({ status: scheduledEventStatus }) ? '[Draft] - ' : ''}
-        {isCompletedEvent({ status: scheduledEventStatus })
-          ? '[Completed] - '
-          : ''}
+        [{ScheduledEventStatusMap[scheduledEventStatus]}] -{' '}
         {proposal.proposalId}
       </div>
       <div className={classes.title}>{proposal.title}</div>

--- a/src/components/proposalBooking/ProposalBookingTreeTitle.tsx
+++ b/src/components/proposalBooking/ProposalBookingTreeTitle.tsx
@@ -2,10 +2,12 @@ import { makeStyles } from '@material-ui/core';
 import humanizeDuration from 'humanize-duration';
 import React from 'react';
 
+import { ScheduledEventStatusMap } from 'components/scheduledEvent/ScheduledEventForm';
+import { ProposalBookingStatus } from 'generated/sdk';
 import { InstrumentProposalBooking } from 'hooks/proposalBooking/useInstrumentProposalBookings';
 import { parseTzLessDateTime } from 'utils/date';
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme) => ({
   heading1: {
     fontSize: '17px',
     fontWeight: 'normal',
@@ -13,13 +15,16 @@ const useStyles = makeStyles(() => ({
     lineHeight: 1.2,
     padding: 0,
   },
+  headingCompleted: {
+    color: theme.palette.grey[500],
+  },
   heading2: {
     fontSize: '14px',
     fontWeight: 'normal',
     fontStyle: 'italic',
     margin: 0,
     padding: 0,
-    color: '#888',
+    color: theme.palette.grey[500],
   },
 }));
 
@@ -55,9 +60,21 @@ function ProposalBookingTreeTitle({
     return null;
   }
 
+  const isProposalBookingCompleted =
+    proposalBooking.status === ProposalBookingStatus.COMPLETED;
+
   return (
     <>
-      <h1 className={classes.heading1}>{proposalBooking.proposal.title}</h1>
+      <h1
+        className={`${classes.heading1} ${
+          isProposalBookingCompleted ? classes.headingCompleted : ''
+        }`}
+      >
+        {proposalBooking.proposal.title}{' '}
+        {isProposalBookingCompleted
+          ? `- [${ScheduledEventStatusMap[proposalBooking.status]}]`
+          : ''}
+      </h1>
       <h2 className={classes.heading2}>{formatTimeRemaining(allocatable)}</h2>
     </>
   );

--- a/src/components/proposalBooking/bookingSteps/BookingEventStep.tsx
+++ b/src/components/proposalBooking/bookingSteps/BookingEventStep.tsx
@@ -34,6 +34,7 @@ import React, {
   useState,
 } from 'react';
 
+import IdentifierIcon from 'components/common/icons/IdentifierIcon';
 import Loader from 'components/common/Loader';
 import { tableIcons } from 'components/common/TableIcons';
 import TimeSlotBookingDialog from 'components/timeSlotBooking/TimeSlotBookingDialog';
@@ -86,11 +87,11 @@ export default function BookingEventStep({
   handleSetActiveStepByStatus,
   handleNext,
 }: ProposalBookingDialogStepProps) {
-  const isStepReadOnly = activeStatus !== ProposalBookingStatus.DRAFT;
+  const isStepReadOnly = activeStatus === ProposalBookingStatus.COMPLETED;
 
   const {
     call: { startCycle, endCycle, cycleComment },
-    proposal: { title },
+    proposal: { title, proposalId },
   } = proposalBooking;
 
   const classes = useStyles();
@@ -333,6 +334,12 @@ export default function BookingEventStep({
                   </Avatar>
                 </ListItemAvatar>
                 <ListItemText primary="Proposal title" secondary={title} />
+                <ListItemAvatar>
+                  <Avatar>
+                    <IdentifierIcon />
+                  </Avatar>
+                </ListItemAvatar>
+                <ListItemText primary="Proposal ID" secondary={proposalId} />
               </ListItem>
               <Divider
                 variant="inset"

--- a/src/components/scheduledEvent/ScheduledEventForm.tsx
+++ b/src/components/scheduledEvent/ScheduledEventForm.tsx
@@ -6,7 +6,10 @@ import { TextField } from 'formik-material-ui';
 import { KeyboardDateTimePicker } from 'formik-material-ui-pickers';
 import React from 'react';
 
-import { ScheduledEventBookingType } from 'generated/sdk';
+import {
+  ProposalBookingStatus,
+  ScheduledEventBookingType,
+} from 'generated/sdk';
 import { TZ_LESS_DATE_TIME_FORMAT } from 'utils/date';
 
 export type BookingTypes = typeof ScheduledEventBookingType;
@@ -25,6 +28,17 @@ export const CalendarExplicitBookableTypes: Record<
 > = {
   MAINTENANCE: 'Maintenance',
   SHUTDOWN: 'Shutdown',
+};
+
+export type ProposalBookingStatusType = typeof ProposalBookingStatus;
+
+export const ScheduledEventStatusMap: Record<
+  keyof ProposalBookingStatusType,
+  string
+> = {
+  DRAFT: 'Draft',
+  ACTIVE: 'Active',
+  COMPLETED: 'Completed',
 };
 
 export default function ScheduledEventForm() {

--- a/src/components/timeSlotBooking/TimeSlotBookingDialog.tsx
+++ b/src/components/timeSlotBooking/TimeSlotBookingDialog.tsx
@@ -22,8 +22,8 @@ import useScheduledEventWithEquipment, {
   ScheduledEventWithEquipments,
 } from 'hooks/scheduledEvent/useScheduledEventWithEquipment';
 
-import TimeSlotBookingEventStep from './timeSlotBookingSteps/TimeSlotBookingEventStep';
 import TimeSlotCompletedStep from './timeSlotBookingSteps/TimeSlotCompletedStep';
+import TimeSlotDetailsStep from './timeSlotBookingSteps/TimeSlotDetailsStep';
 import TimeSlotEquipmentBookingStep from './timeSlotBookingSteps/TimeSlotEquipmentBookingStep';
 import TimeSlotFinalizeStep from './timeSlotBookingSteps/TimeSlotFinalizeStep';
 
@@ -58,7 +58,7 @@ const steps = [
 ];
 const maxSteps = steps.length;
 
-export type ProposalBookingDialogStepProps = {
+export type TimeSlotBookingDialogStepProps = {
   activeStep: number;
   activeStatus: ProposalBookingStatus | null;
   scheduledEvent: ScheduledEventWithEquipments;
@@ -74,10 +74,10 @@ export type ProposalBookingDialogStepProps = {
   handleSetActiveStepByStatus: (status: ProposalBookingStatus) => void;
 };
 
-function getActiveStep(props: ProposalBookingDialogStepProps) {
+function getActiveStep(props: TimeSlotBookingDialogStepProps) {
   switch (props.activeStep) {
     case ProposalBookingSteps.BOOK_EVENTS:
-      return <TimeSlotBookingEventStep {...props} />;
+      return <TimeSlotDetailsStep {...props} />;
     case ProposalBookingSteps.BOOK_EQUIPMENT:
       return <TimeSlotEquipmentBookingStep {...props} />;
     case ProposalBookingSteps.FINALIZE:

--- a/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotCompletedStep.tsx
+++ b/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotCompletedStep.tsx
@@ -13,7 +13,7 @@ import useProposalBookingLostTimes from 'hooks/lostTime/useProposalBookingLostTi
 import { parseTzLessDateTime } from 'utils/date';
 
 import TimeTable, { TimeTableRow } from '../../proposalBooking/TimeTable';
-import { ProposalBookingDialogStepProps } from '../TimeSlotBookingDialog';
+import { TimeSlotBookingDialogStepProps } from '../TimeSlotBookingDialog';
 
 const useStyles = makeStyles(() => ({
   resetFlex: {
@@ -25,7 +25,7 @@ const useStyles = makeStyles(() => ({
 export default function TimeSlotCompletedStep({
   scheduledEvent,
   handleCloseDialog,
-}: ProposalBookingDialogStepProps) {
+}: TimeSlotBookingDialogStepProps) {
   const classes = useStyles();
   const proposalBooking = scheduledEvent.proposalBooking as ProposalBooking;
 

--- a/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotDetailsStep.tsx
+++ b/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotDetailsStep.tsx
@@ -22,6 +22,7 @@ import {
   FolderOpen as FolderOpenIcon,
   Check as CheckIcon,
   Clear as ClearIcon,
+  Edit,
 } from '@material-ui/icons';
 import {
   KeyboardDateTimePicker,
@@ -33,6 +34,7 @@ import moment, { Moment } from 'moment';
 import { useSnackbar } from 'notistack';
 import React, { useContext, useMemo, useState } from 'react';
 
+import IdentifierIcon from 'components/common/icons/IdentifierIcon';
 import Loader from 'components/common/Loader';
 import { AppContext } from 'context/AppContext';
 import { ProposalBooking, ProposalBookingStatus } from 'generated/sdk';
@@ -43,7 +45,7 @@ import {
 } from 'utils/date';
 import { hasOverlappingEvents } from 'utils/scheduledEvent';
 
-import { ProposalBookingDialogStepProps } from '../TimeSlotBookingDialog';
+import { TimeSlotBookingDialogStepProps } from '../TimeSlotBookingDialog';
 
 const useStyles = makeStyles((theme) => ({
   list: {
@@ -71,6 +73,11 @@ const useStyles = makeStyles((theme) => ({
   smaller: {
     fontSize: '0.875rem',
   },
+  editIcon: {
+    marginLeft: theme.spacing(1),
+    cursor: 'pointer',
+    position: 'absolute',
+  },
 }));
 
 const formatDuration = (durSec: number) =>
@@ -80,7 +87,7 @@ const formatDuration = (durSec: number) =>
     largest: 3,
   });
 
-export default function TimeSlotBookingEventStep({
+export default function TimeSlotDetailsStep({
   activeStatus,
   scheduledEvent,
   setScheduledEvent,
@@ -88,10 +95,12 @@ export default function TimeSlotBookingEventStep({
   handleNext,
   handleSetDirty,
   handleCloseDialog,
-}: ProposalBookingDialogStepProps) {
+}: TimeSlotBookingDialogStepProps) {
   const proposalBooking = scheduledEvent.proposalBooking as ProposalBooking;
   const [editingStartDate, setEditingStartDate] = useState(false);
   const [editingEndDate, setEditingEndDate] = useState(false);
+  const [showStartsAtEditIcon, setShowStartsAtEditIcon] = useState(false);
+  const [showEndsAtEditIcon, setShowEndsAtEditIcon] = useState(false);
 
   const isStepReadOnly = activeStatus !== ProposalBookingStatus.DRAFT;
 
@@ -252,12 +261,28 @@ export default function TimeSlotBookingEventStep({
                     </Avatar>
                   </ListItemAvatar>
                   {!editingStartDate && (
-                    <ListItemText
-                      onClick={() => setEditingStartDate(true)}
-                      primary="Starts at"
-                      data-cy="startsAtInfo"
-                      secondary={toTzLessDateTime(startsAt as Moment)}
-                    />
+                    <>
+                      <ListItemText
+                        onClick={() => setEditingStartDate(!isStepReadOnly)}
+                        onMouseOver={() =>
+                          setShowStartsAtEditIcon(!isStepReadOnly)
+                        }
+                        onMouseLeave={() => setShowStartsAtEditIcon(false)}
+                        primary="Starts at"
+                        data-cy="startsAtInfo"
+                        secondary={
+                          <>
+                            {toTzLessDateTime(startsAt as Moment)}
+                            {showStartsAtEditIcon && (
+                              <Edit
+                                fontSize="small"
+                                className={classes.editIcon}
+                              />
+                            )}
+                          </>
+                        }
+                      />
+                    </>
                   )}
                   {editingStartDate && (
                     <>
@@ -361,8 +386,20 @@ export default function TimeSlotBookingEventStep({
                     <ListItemText
                       primary="Ends at"
                       data-cy="endsAtInfo"
-                      onClick={() => setEditingEndDate(true)}
-                      secondary={toTzLessDateTime(endsAt as Moment)}
+                      onMouseOver={() => setShowEndsAtEditIcon(!isStepReadOnly)}
+                      onMouseLeave={() => setShowEndsAtEditIcon(false)}
+                      onClick={() => setEditingEndDate(!isStepReadOnly)}
+                      secondary={
+                        <>
+                          {toTzLessDateTime(endsAt as Moment)}
+                          {showEndsAtEditIcon && (
+                            <Edit
+                              fontSize="small"
+                              className={classes.editIcon}
+                            />
+                          )}
+                        </>
+                      }
                     />
                   )}
                   {editingEndDate && (
@@ -423,6 +460,17 @@ export default function TimeSlotBookingEventStep({
                   component="li"
                   className={classes.divider}
                 />
+                <ListItem disableGutters>
+                  <ListItemAvatar>
+                    <Avatar>
+                      <IdentifierIcon />
+                    </Avatar>
+                  </ListItemAvatar>
+                  <ListItemText
+                    primary="Proposal ID"
+                    secondary={proposalBooking.proposal?.proposalId}
+                  />
+                </ListItem>
               </List>
             </Grid>
           </MuiPickersUtilsProvider>

--- a/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotEquipmentBookingStep.tsx
+++ b/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotEquipmentBookingStep.tsx
@@ -33,7 +33,7 @@ import { DetailedProposalBooking } from 'hooks/proposalBooking/useProposalBookin
 import useScheduledEventEquipments from 'hooks/scheduledEvent/useScheduledEventEquipments';
 import { ScheduledEventEquipment } from 'hooks/scheduledEvent/useScheduledEventWithEquipment';
 
-import { ProposalBookingDialogStepProps } from '../TimeSlotBookingDialog';
+import { TimeSlotBookingDialogStepProps } from '../TimeSlotBookingDialog';
 
 export type EquipmentTableRow = {
   id: string;
@@ -66,7 +66,7 @@ export default function TimeSlotEquipmentBookingStep({
   handleBack,
   handleSetActiveStepByStatus,
   handleCloseDialog,
-}: ProposalBookingDialogStepProps) {
+}: TimeSlotBookingDialogStepProps) {
   const proposalBooking = scheduledEvent.proposalBooking as ProposalBooking;
   const isStepReadOnly = activeStatus !== ProposalBookingStatus.DRAFT;
 

--- a/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotFinalizeStep.tsx
+++ b/src/components/timeSlotBooking/timeSlotBookingSteps/TimeSlotFinalizeStep.tsx
@@ -25,7 +25,7 @@ import { parseTzLessDateTime, toTzLessDateTime } from 'utils/date';
 import { hasOverlappingEvents } from 'utils/scheduledEvent';
 
 import TimeTable, { TimeTableRow } from '../../proposalBooking/TimeTable';
-import { ProposalBookingDialogStepProps } from '../TimeSlotBookingDialog';
+import { TimeSlotBookingDialogStepProps } from '../TimeSlotBookingDialog';
 
 const useStyles = makeStyles((theme) => ({
   spacing: {
@@ -49,7 +49,7 @@ export default function TimeSlotFinalizeStep({
   handleResetSteps,
   handleSetActiveStepByStatus,
   handleCloseDialog,
-}: ProposalBookingDialogStepProps) {
+}: TimeSlotBookingDialogStepProps) {
   const proposalBooking = scheduledEvent.proposalBooking as ProposalBooking;
   const isStepReadOnly = activeStatus !== ProposalBookingStatus.ACTIVE;
 


### PR DESCRIPTION
## Description

1. Added edit icon next to starting and ending time for scheduled event.
2. Marked completed proposal booking with different color inside the right proposal booking toolbar for better user experience.
3. Added proposal ID to the Scheduled event view and proposal booking view.

## How Has This Been Tested

- e2e tests
- manual tests

## Fixes

https://jira.esss.lu.se/browse/SWAP-1766
https://jira.esss.lu.se/browse/SWAP-1797

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
