### PR TITLE
Swap 1925 unlock completed events

### DIFF
--- a/cypress/integration/proposal-booking.spec.ts
+++ b/cypress/integration/proposal-booking.spec.ts
@@ -837,6 +837,87 @@ context('Proposal booking tests ', () => {
           .and('include', 'background: rgb(')
           .and('include', 'filter: grayscale(0.5) opacity(1)');
       });
+
+      it('Instrument scientist should not be able to re-open completed events', () => {
+        cy.initializeSession('InstrumentScientist_1');
+
+        cy.visit({
+          url: '/calendar',
+          timeout: 15000,
+        });
+
+        cy.finishedLoading();
+        cy.get('[data-cy=input-instrument-select]').click();
+
+        cy.get('[aria-labelledby=input-instrument-select-label] [role=option]')
+          .first()
+          .click();
+        cy.get('#instrument-calls-tree-view [role=treeitem]').first().click();
+
+        cy.get(
+          '#instrument-calls-tree-view [role=treeitem] [role=group] [role=treeitem]'
+        )
+          .first()
+          .click();
+
+        cy.get('[data-cy="btn-reopen-booking"]').should('not.exist');
+
+        cy.get('[title="Edit event"]').first().click();
+
+        cy.finishedLoading();
+
+        cy.get('[data-cy="btn-reopen-time-slot-booking"]').should('not.exist');
+      });
+
+      it('User officer should be able to re-open completed events', () => {
+        cy.initializeSession('UserOfficer');
+
+        cy.visit({
+          url: '/calendar',
+          timeout: 15000,
+        });
+
+        cy.finishedLoading();
+        cy.get('[data-cy=input-instrument-select]').click();
+
+        cy.get('[aria-labelledby=input-instrument-select-label] [role=option]')
+          .last()
+          .click();
+        cy.get('#instrument-calls-tree-view [role=treeitem]').first().click();
+
+        cy.get(
+          '#instrument-calls-tree-view [role=treeitem] [role=group] [role=treeitem]'
+        )
+          .first()
+          .click();
+
+        cy.get('[data-cy="btn-reopen-booking"]').should(
+          'include.text',
+          'Reopen proposal booking'
+        );
+
+        cy.get('[title="Edit event"]').first().click();
+
+        cy.finishedLoading();
+
+        cy.get('[data-cy="btn-reopen-time-slot-booking"]')
+          .should('include.text', 'Reopen time slot booking')
+          .click();
+
+        cy.contains(/confirmation/i);
+        cy.contains(/Are you sure you want to re-open the selected time slot/i);
+
+        cy.get('[data-cy="btn-ok"]').click();
+
+        cy.finishedLoading();
+
+        cy.get('[title="Add lost time"]').should('exist');
+        cy.contains('Complete the time slot booking');
+
+        cy.get('[data-cy="btn-close-event-dialog"]').click();
+
+        cy.get('[data-cy="btn-reopen-booking"]').should('not.exist');
+      });
     });
   });
 });

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -1,7 +1,7 @@
 import { getTranslation } from '@esss-swap/duo-localisation';
 import { decode } from 'jsonwebtoken';
 import { useSnackbar } from 'notistack';
-import React, { createContext, useEffect, useReducer } from 'react';
+import React, { createContext, useContext, useEffect, useReducer } from 'react';
 import { useCookies } from 'react-cookie';
 
 import Loader from 'components/common/Loader';
@@ -16,6 +16,7 @@ export type UserContextData = {
   stateInitialized: boolean;
   user: AuthenticatedUser | null;
   token: string | null;
+  currentRole: UserRole | null;
   roles: Role[];
   handleNewToken: (token: string) => void;
   handleLogout: () => void;
@@ -26,6 +27,7 @@ const initialState = {
   user: null,
   token: null,
   roles: [],
+  currentRole: null,
   handleNewToken: () => {},
   handleLogout: () => {},
 };
@@ -57,6 +59,8 @@ function reducer(
 
         user: action.payload.decodedToken.user,
         roles: action.payload.decodedToken.roles,
+        currentRole:
+          action.payload.decodedToken.currentRole.shortCode.toUpperCase(),
         token: action.payload.token,
         stateInitialized: true,
       };
@@ -139,3 +143,17 @@ export function UserContextProvider({ children }: UserContextProviderProps) {
     </UserContext.Provider>
   );
 }
+
+export const useCheckAccess = (allowedRoles: UserRole[]) => {
+  const { currentRole } = useContext(UserContext);
+
+  if (!currentRole) {
+    return false;
+  }
+
+  if (allowedRoles.includes(currentRole)) {
+    return true;
+  }
+
+  return false;
+};

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -440,6 +440,7 @@ export enum Event {
   PROPOSAL_ALL_SEP_REVIEWS_SUBMITTED = 'PROPOSAL_ALL_SEP_REVIEWS_SUBMITTED',
   PROPOSAL_BOOKING_TIME_ACTIVATED = 'PROPOSAL_BOOKING_TIME_ACTIVATED',
   PROPOSAL_BOOKING_TIME_COMPLETED = 'PROPOSAL_BOOKING_TIME_COMPLETED',
+  PROPOSAL_BOOKING_TIME_REOPENED = 'PROPOSAL_BOOKING_TIME_REOPENED',
   PROPOSAL_BOOKING_TIME_SLOTS_REMOVED = 'PROPOSAL_BOOKING_TIME_SLOTS_REMOVED',
   PROPOSAL_BOOKING_TIME_SLOT_ADDED = 'PROPOSAL_BOOKING_TIME_SLOT_ADDED',
   PROPOSAL_BOOKING_TIME_UPDATED = 'PROPOSAL_BOOKING_TIME_UPDATED',
@@ -800,6 +801,8 @@ export type Mutation = {
   removeProposalsFromSep: SepResponseWrap;
   removeScientistFromInstrument: SuccessResponseWrap;
   removeUserForReview: ReviewResponseWrap;
+  reopenProposalBooking: ProposalBookingResponseWrap;
+  reopenScheduledEvent: ScheduledEventResponseWrap;
   reorderSepMeetingDecisionProposals: SepMeetingDecisionResponseWrap;
   resetPassword: BasicUserDetailsResponseWrap;
   resetPasswordEmail: SuccessResponseWrap;
@@ -1390,6 +1393,16 @@ export type MutationRemoveScientistFromInstrumentArgs = {
 export type MutationRemoveUserForReviewArgs = {
   reviewId: Scalars['Int'];
   sepId: Scalars['Int'];
+};
+
+
+export type MutationReopenProposalBookingArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type MutationReopenScheduledEventArgs = {
+  id: Scalars['Int'];
 };
 
 
@@ -3741,6 +3754,19 @@ export type GetProposalBookingQuery = (
   )> }
 );
 
+export type ReopenProposalBookingMutationVariables = Exact<{
+  id: Scalars['Int'];
+}>;
+
+
+export type ReopenProposalBookingMutation = (
+  { __typename?: 'Mutation' }
+  & { reopenProposalBooking: (
+    { __typename?: 'ProposalBookingResponseWrap' }
+    & Pick<ProposalBookingResponseWrap, 'error'>
+  ) }
+);
+
 export type ActivateScheduledEventMutationVariables = Exact<{
   input: ActivateScheduledEventInput;
 }>;
@@ -3972,6 +3998,19 @@ export type GetScheduledEventsWithEquipmentsQuery = (
       & Pick<EquipmentWithAssignmentStatus, 'id' | 'name' | 'description' | 'maintenanceStartsAt' | 'maintenanceEndsAt' | 'status'>
     )> }
   )> }
+);
+
+export type ReopenScheduledEventMutationVariables = Exact<{
+  id: Scalars['Int'];
+}>;
+
+
+export type ReopenScheduledEventMutation = (
+  { __typename?: 'Mutation' }
+  & { reopenScheduledEvent: (
+    { __typename?: 'ScheduledEventResponseWrap' }
+    & Pick<ScheduledEventResponseWrap, 'error'>
+  ) }
 );
 
 export type UpdateScheduledEventMutationVariables = Exact<{
@@ -4320,6 +4359,13 @@ export const GetProposalBookingDocument = gql`
   }
 }
     `;
+export const ReopenProposalBookingDocument = gql`
+    mutation reopenProposalBooking($id: Int!) {
+  reopenProposalBooking(id: $id) {
+    error
+  }
+}
+    `;
 export const ActivateScheduledEventDocument = gql`
     mutation activateScheduledEvent($input: ActivateScheduledEventInput!) {
   activateScheduledEvent(activateScheduledEvent: $input) {
@@ -4562,6 +4608,13 @@ export const GetScheduledEventsWithEquipmentsDocument = gql`
   }
 }
     `;
+export const ReopenScheduledEventDocument = gql`
+    mutation reopenScheduledEvent($id: Int!) {
+  reopenScheduledEvent(id: $id) {
+    error
+  }
+}
+    `;
 export const UpdateScheduledEventDocument = gql`
     mutation updateScheduledEvent($input: UpdateScheduledEventInput!) {
   updateScheduledEvent(updateScheduledEvent: $input) {
@@ -4663,6 +4716,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     getProposalBooking(variables: GetProposalBookingQueryVariables): Promise<GetProposalBookingQuery> {
       return withWrapper(() => client.request<GetProposalBookingQuery>(print(GetProposalBookingDocument), variables));
     },
+    reopenProposalBooking(variables: ReopenProposalBookingMutationVariables): Promise<ReopenProposalBookingMutation> {
+      return withWrapper(() => client.request<ReopenProposalBookingMutation>(print(ReopenProposalBookingDocument), variables));
+    },
     activateScheduledEvent(variables: ActivateScheduledEventMutationVariables): Promise<ActivateScheduledEventMutation> {
       return withWrapper(() => client.request<ActivateScheduledEventMutation>(print(ActivateScheduledEventDocument), variables));
     },
@@ -4692,6 +4748,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     getScheduledEventsWithEquipments(variables: GetScheduledEventsWithEquipmentsQueryVariables): Promise<GetScheduledEventsWithEquipmentsQuery> {
       return withWrapper(() => client.request<GetScheduledEventsWithEquipmentsQuery>(print(GetScheduledEventsWithEquipmentsDocument), variables));
+    },
+    reopenScheduledEvent(variables: ReopenScheduledEventMutationVariables): Promise<ReopenScheduledEventMutation> {
+      return withWrapper(() => client.request<ReopenScheduledEventMutation>(print(ReopenScheduledEventDocument), variables));
     },
     updateScheduledEvent(variables: UpdateScheduledEventMutationVariables): Promise<UpdateScheduledEventMutation> {
       return withWrapper(() => client.request<UpdateScheduledEventMutation>(print(UpdateScheduledEventDocument), variables));

--- a/src/graphql/proposalBooking/reopenProposalBooking.graphql
+++ b/src/graphql/proposalBooking/reopenProposalBooking.graphql
@@ -1,0 +1,5 @@
+mutation reopenProposalBooking($id: Int!) {
+  reopenProposalBooking(id: $id) {
+    error
+  }
+}

--- a/src/graphql/scheduledEvent/reopenScheduledEvent.graphql
+++ b/src/graphql/scheduledEvent/reopenScheduledEvent.graphql
@@ -1,0 +1,5 @@
+mutation reopenScheduledEvent($id: Int!) {
+  reopenScheduledEvent(id: $id) {
+    error
+  }
+}


### PR DESCRIPTION
## Description

Unlock completed time slots and proposal bookings. For now only user officer can do it.

## Motivation and Context

Previously there was no way to unlock already completed events or proposal bookings.

## How Has This Been Tested

- e2e tests
- manual tests

## Fixes

https://jira.esss.lu.se/browse/SWAP-1925

## Depends on

https://github.com/UserOfficeProject/user-office-scheduler-backend/pull/88

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
