### PR TITLE
Swap 2015 assign local contact to timeslot

### DIFF
--- a/codegen_template.yml
+++ b/codegen_template.yml
@@ -4,6 +4,7 @@ documents: "src/graphql/**/*.graphql"
 generates:
   src/generated/sdk.ts:
     config:
+      skipTypename: true
       namingConvention:
         typeNames: change-case#pascalCase
         enumValues: change-case#upperCase

--- a/cypress/integration/proposal-booking.spec.ts
+++ b/cypress/integration/proposal-booking.spec.ts
@@ -273,6 +273,33 @@ context('Proposal booking tests ', () => {
         cy.contains(getHourDateTimeAfter(3, 'days'));
       });
 
+      it('should be able to add and edit local contact on the timeslot', () => {
+        cy.finishedLoading();
+        cy.get('.MuiTab-fullWidth').last().click();
+
+        cy.get('[data-cy="local-contact-details"]').should(
+          'contain.text',
+          'None'
+        );
+
+        cy.get('[data-cy="add-local-contact"]').click();
+        cy.get('[data-cy="select-user"]').first().click();
+
+        cy.get('[data-cy="local-contact-details"]')
+          .should('not.contain.text', 'None')
+          .invoke('text')
+          .then((selectedLocalContactText: string) => {
+            cy.get('[data-cy="edit-local-contact"]').should('exist').click();
+
+            cy.get('[data-cy="select-user"]').last().click();
+
+            cy.get('[data-cy="local-contact-details"]')
+              .should('not.contain.text', 'None')
+              .invoke('text')
+              .should('not.equal', selectedLocalContactText);
+          });
+      });
+
       it('should be able to open time slot by clicking on the calendar event', () => {
         cy.get('[data-cy="btn-close-dialog"]').click();
         cy.finishedLoading();

--- a/src/components/appToolbar/AppToolbar.tsx
+++ b/src/components/appToolbar/AppToolbar.tsx
@@ -20,6 +20,7 @@ import clsx from 'clsx';
 import React, { useState, useContext } from 'react';
 
 import { UserContext } from 'context/UserContext';
+import { getFullUserName } from 'utils/user';
 
 export const drawerWidth = 240;
 
@@ -125,7 +126,7 @@ export default function AppToolbar({
             <Card>
               <CardHeader
                 avatar={<Avatar />}
-                title={`${user?.firstname} ${user?.lastname}`}
+                title={getFullUserName(user)}
                 subheader={user?.email}
               />
             </Card>

--- a/src/components/calendar/Event.tsx
+++ b/src/components/calendar/Event.tsx
@@ -11,6 +11,7 @@ import {
   ScheduledEvent,
   ScheduledEventBookingType,
 } from 'generated/sdk';
+import { getFullUserName } from 'utils/user';
 
 export type BasicProposalBooking =
   GetScheduledEventsQuery['scheduledEvents'][number]['proposalBooking'];
@@ -133,9 +134,7 @@ export default function Event({
         <EquipmentBookingInfo
           name={description ?? 'NA'}
           instrument={instrument?.name ?? 'NA'}
-          scheduledBy={
-            `${scheduledBy?.firstname} ${scheduledBy?.lastname}` ?? 'NA'
-          }
+          scheduledBy={getFullUserName(scheduledBy)}
           proposalBooking={{ status }}
         />
       );

--- a/src/components/common/PeopleModal.tsx
+++ b/src/components/common/PeopleModal.tsx
@@ -12,8 +12,9 @@ function PeopleModal(props: {
   show: boolean;
   close: () => void;
   selection?: boolean;
-  selectedUsers?: number[];
+  selectedUsers?: number[] | null;
   userRole?: UserRole;
+  data?: BasicUserDetails[];
 }) {
   const addUser = (rowData: BasicUserDetails) => {
     props.addParticipants([
@@ -47,6 +48,7 @@ function PeopleModal(props: {
           selection={!!props.selection}
           userRole={props.userRole}
           onUpdate={(data) => props.addParticipants(data as BasicUserDetails[])}
+          data={props.data}
         />
       </DialogContent>
     </Dialog>

--- a/src/components/common/PeopleTable.tsx
+++ b/src/components/common/PeopleTable.tsx
@@ -13,7 +13,7 @@ function sendUserRequest(
   searchQuery: Query<any>,
   api: any,
   setLoading: React.Dispatch<React.SetStateAction<boolean>>,
-  selectedUsers: number[] | undefined,
+  selectedUsers: number[] | undefined | null,
   selectedParticipants: number[],
   userRole: UserRole | null
 ) {
@@ -62,7 +62,7 @@ type PeopleTableProps<T extends BasicUserDetails = BasicUserDetails> = {
   search?: boolean;
   onRemove?: (item: any) => void;
   onUpdate?: (item: any[]) => void;
-  selectedUsers?: number[];
+  selectedUsers?: number[] | null;
   mtOptions?: Options<BasicUserDetails>;
   columns?: Column<any>[];
   userRole?: UserRole;

--- a/src/components/equipment/ViewEquipment.tsx
+++ b/src/components/equipment/ViewEquipment.tsx
@@ -289,8 +289,8 @@ export default function ViewEquipment({ equipmentId }: ViewEquipmentProps) {
   return (
     <ContentContainer maxWidth={false}>
       <PeopleModal
-        show={!!showPeopleModal}
-        close={(): void => setShowPeopleModal(false)}
+        show={showPeopleModal}
+        close={() => setShowPeopleModal(false)}
         addParticipants={addEquipmentResponsibleUsers}
         selectedUsers={selectedUsers.map((selectedUser) => selectedUser.id)}
         selection={true}
@@ -298,8 +298,8 @@ export default function ViewEquipment({ equipmentId }: ViewEquipmentProps) {
         userRole={UserRole.INSTRUMENT_SCIENTIST}
       />
       <PeopleModal
-        show={!!showEquipmentOwnerSelectionModal}
-        close={(): void => setShowEquipmentOwnerSelectionModal(false)}
+        show={showEquipmentOwnerSelectionModal}
+        close={() => setShowEquipmentOwnerSelectionModal(false)}
         addParticipants={updateEquipmentOwner}
         selectedUsers={equipment.owner ? [equipment.owner.id] : []}
         title={'Select equipment owner'}

--- a/src/components/equipment/ViewEquipment.tsx
+++ b/src/components/equipment/ViewEquipment.tsx
@@ -44,6 +44,7 @@ import useEquipment from 'hooks/equipment/useEquipment';
 import useEquipmentScheduledEvents from 'hooks/scheduledEvent/useEquipmentScheduledEvents';
 import { ContentContainer, StyledPaper } from 'styles/StyledComponents';
 import { parseTzLessDateTime, toTzLessDateTime } from 'utils/date';
+import { getFullUserName } from 'utils/user';
 
 type TableRow = {
   id: number;
@@ -340,9 +341,7 @@ export default function ViewEquipment({ equipmentId }: ViewEquipmentProps) {
                     </ListItemAvatar>
                     <ListItemText
                       primary="Owner"
-                      secondary={`${equipment?.owner?.firstname ?? 'Unknown'} ${
-                        equipment?.owner?.lastname
-                      }`}
+                      secondary={getFullUserName(equipment.owner)}
                       className={classes.listItemText}
                     />
                     <Tooltip title="Change equipment owner">
@@ -367,9 +366,7 @@ export default function ViewEquipment({ equipmentId }: ViewEquipmentProps) {
                       primary="Responsible people"
                       secondary={selectedUsers.map(
                         (user, index) =>
-                          `${index ? ', ' : ''} ${user.firstname} ${
-                            user.lastname
-                          }`
+                          `${index ? ', ' : ''} ${getFullUserName(user)}`
                       )}
                       className={classes.listItemText}
                     />

--- a/src/components/proposalBooking/ProposalBookingInfo.tsx
+++ b/src/components/proposalBooking/ProposalBookingInfo.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { BasicProposalBooking } from 'components/calendar/Event';
 import { ScheduledEventStatusMap } from 'components/scheduledEvent/ScheduledEventForm';
 import { ProposalBookingStatusCore } from 'generated/sdk';
+import { getFullUserName } from 'utils/user';
 
 const useStyles = makeStyles(() => ({
   container: {
@@ -57,7 +58,7 @@ function ProposalBookingInfo({
       </div>
       <div className={classes.title}>{proposal.title}</div>
       <div className={classes.proposer}>
-        {`${proposal.proposer?.firstname} ${proposal.proposer?.lastname}`}
+        {getFullUserName(proposal.proposer)}
       </div>
     </div>
   );

--- a/src/components/requests/ViewRequests.tsx
+++ b/src/components/requests/ViewRequests.tsx
@@ -13,6 +13,7 @@ import { useDataApi } from 'hooks/common/useDataApi';
 import useEquipmentScheduledEvents from 'hooks/scheduledEvent/useEquipmentScheduledEvents';
 import { ContentContainer, StyledPaper } from 'styles/StyledComponents';
 import { parseTzLessDateTime, toTzLessDateTime } from 'utils/date';
+import { getFullUserName } from 'utils/user';
 
 type TableRow = {
   id: number;
@@ -80,7 +81,7 @@ export default function ViewRequests() {
               instrumentName: instrument?.name,
               proposalTitle: proposalBooking?.proposal?.title,
               proposalId: proposalBooking?.proposal?.proposalId,
-              scheduledBy: `${scheduledBy?.firstname} ${scheduledBy?.lastname}`,
+              scheduledBy: getFullUserName(scheduledBy),
             })
           )
         );

--- a/src/components/timeSlotBooking/TimeSlotBooking.tsx
+++ b/src/components/timeSlotBooking/TimeSlotBooking.tsx
@@ -246,6 +246,7 @@ export default function TimeSlotBooking({
           scheduledEventId: activeScheduledEvent.id,
           startsAt: toTzLessDateTime(activeScheduledEvent.startsAt),
           endsAt: toTzLessDateTime(activeScheduledEvent.endsAt),
+          localContact: activeScheduledEvent.localContact?.id,
         },
       });
 

--- a/src/components/timeSlotBooking/TimeSlotDetails.tsx
+++ b/src/components/timeSlotBooking/TimeSlotDetails.tsx
@@ -289,30 +289,26 @@ export default function TimeSlotDetails({
                 </ListItemAvatar>
                 <ListItemText
                   primary="Local contact"
+                  data-cy="local-contact-details"
                   secondary={
                     <>
                       {getFullUserName(scheduledEvent.localContact)}
-                      {isEditable && (
-                        <IconButton
-                          onClick={() => setShowPeopleModal(true)}
-                          data-cy="add-edit-local-contact"
-                          aria-label={`${
-                            scheduledEvent.localContact ? 'Edit' : 'Add'
-                          } local contact`}
-                        >
-                          {!scheduledEvent.localContact ? (
-                            <PersonAddIcon
-                              fontSize="small"
-                              className={classes.editIcon}
-                            />
-                          ) : (
-                            <Edit
-                              fontSize="small"
-                              className={classes.editIcon}
-                            />
-                          )}
-                        </IconButton>
-                      )}
+                      {isEditable &&
+                        (!scheduledEvent.localContact ? (
+                          <PersonAddIcon
+                            onClick={() => setShowPeopleModal(true)}
+                            fontSize="small"
+                            data-cy="add-local-contact"
+                            className={classes.editIcon}
+                          />
+                        ) : (
+                          <Edit
+                            onClick={() => setShowPeopleModal(true)}
+                            fontSize="small"
+                            data-cy="edit-local-contact"
+                            className={classes.editIcon}
+                          />
+                        ))}
                     </>
                   }
                 />

--- a/src/components/timeSlotBooking/TimeSlotDetails.tsx
+++ b/src/components/timeSlotBooking/TimeSlotDetails.tsx
@@ -34,7 +34,6 @@ import {
   BasicUserDetails,
   ProposalBookingStatusCore,
   ScheduledEvent,
-  User,
   UserRole,
 } from 'generated/sdk';
 import { InstrumentProposalBooking } from 'hooks/proposalBooking/useInstrumentProposalBookings';
@@ -170,7 +169,7 @@ export default function TimeSlotDetails({
       handleSetDirty(true);
       onSave({
         ...scheduledEvent,
-        localContact: selectedLocalContact as unknown as User,
+        localContact: selectedLocalContact,
       });
     }
 
@@ -192,15 +191,15 @@ export default function TimeSlotDetails({
         </Alert>
       )}
       <PeopleModal
-        show={!!showPeopleModal}
-        close={(): void => setShowPeopleModal(false)}
+        show={showPeopleModal}
+        close={() => setShowPeopleModal(false)}
         addParticipants={addLocalContact}
         selectedUsers={
           scheduledEvent.localContact && [scheduledEvent.localContact.id]
         }
         title={'Select local contact'}
         userRole={UserRole.INSTRUMENT_SCIENTIST}
-        data={localContactOptions as BasicUserDetails[]}
+        data={localContactOptions}
       />
       <Grid container spacing={2}>
         <MuiPickersUtilsProvider utils={MomentUtils}>

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -175,6 +175,7 @@ export type Call = {
   startNotify: Scalars['DateTime'];
   startReview: Scalars['DateTime'];
   startSEPReview: Maybe<Scalars['DateTime']>;
+  submissionMessage: Maybe<Scalars['String']>;
   surveyComment: Scalars['String'];
   template: Template;
   templateId: Scalars['Int'];
@@ -198,12 +199,6 @@ export type CallsFilter = {
 export type ChangeProposalsStatusInput = {
   proposals: Array<ProposalPkWithCallId>;
   statusId: Scalars['Int'];
-};
-
-export type CheckExternalTokenWrap = {
-  __typename?: 'CheckExternalTokenWrap';
-  rejection: Maybe<Rejection>;
-  token: Maybe<Scalars['String']>;
 };
 
 export type CloneProposalsInput = {
@@ -241,6 +236,7 @@ export type CreateCallInput = {
   startNotify: Scalars['DateTime'];
   startReview: Scalars['DateTime'];
   startSEPReview?: Maybe<Scalars['DateTime']>;
+  submissionMessage?: Maybe<Scalars['String']>;
   surveyComment: Scalars['String'];
   templateId: Scalars['Int'];
   title?: Maybe<Scalars['String']>;
@@ -267,6 +263,7 @@ export enum DataType {
   BOOLEAN = 'BOOLEAN',
   DATE = 'DATE',
   EMBELLISHMENT = 'EMBELLISHMENT',
+  FEEDBACK_BASIS = 'FEEDBACK_BASIS',
   FILE_UPLOAD = 'FILE_UPLOAD',
   GENERIC_TEMPLATE = 'GENERIC_TEMPLATE',
   GENERIC_TEMPLATE_BASIS = 'GENERIC_TEMPLATE_BASIS',
@@ -510,6 +507,12 @@ export type ExperimentSafetyInput = {
   scheduledEventId: Scalars['Int'];
 };
 
+export type ExternalTokenLoginWrap = {
+  __typename?: 'ExternalTokenLoginWrap';
+  rejection: Maybe<Rejection>;
+  token: Maybe<Scalars['String']>;
+};
+
 export type Feature = {
   __typename?: 'Feature';
   description: Scalars['String'];
@@ -525,6 +528,41 @@ export enum FeatureId {
   SHIPPING = 'SHIPPING'
 }
 
+export type Feedback = {
+  __typename?: 'Feedback';
+  createdAt: Scalars['DateTime'];
+  creatorId: Scalars['Int'];
+  id: Scalars['Int'];
+  questionary: Questionary;
+  questionaryId: Scalars['Int'];
+  scheduledEventId: Scalars['Int'];
+  status: FeedbackStatus;
+  submittedAt: Maybe<Scalars['DateTime']>;
+};
+
+export type FeedbackBasisConfig = {
+  __typename?: 'FeedbackBasisConfig';
+  required: Scalars['Boolean'];
+  small_label: Scalars['String'];
+  tooltip: Scalars['String'];
+};
+
+export type FeedbackResponseWrap = {
+  __typename?: 'FeedbackResponseWrap';
+  feedback: Maybe<Feedback>;
+  rejection: Maybe<Rejection>;
+};
+
+export enum FeedbackStatus {
+  DRAFT = 'DRAFT',
+  SUBMITTED = 'SUBMITTED'
+}
+
+export type FeedbacksFilter = {
+  creatorId?: Maybe<Scalars['Int']>;
+  scheduledEventId?: Maybe<Scalars['Int']>;
+};
+
 export type FieldCondition = {
   __typename?: 'FieldCondition';
   condition: EvaluatorOperator;
@@ -536,7 +574,7 @@ export type FieldConditionInput = {
   params: Scalars['String'];
 };
 
-export type FieldConfig = BooleanConfig | DateConfig | EmbellishmentConfig | FileUploadConfig | GenericTemplateBasisConfig | IntervalConfig | NumberInputConfig | ProposalBasisConfig | ProposalEsiBasisConfig | RichTextInputConfig | SampleBasisConfig | SampleDeclarationConfig | SampleEsiBasisConfig | SelectionFromOptionsConfig | ShipmentBasisConfig | SubTemplateConfig | TextInputConfig | VisitBasisConfig;
+export type FieldConfig = BooleanConfig | DateConfig | EmbellishmentConfig | FeedbackBasisConfig | FileUploadConfig | GenericTemplateBasisConfig | IntervalConfig | NumberInputConfig | ProposalBasisConfig | ProposalEsiBasisConfig | RichTextInputConfig | SampleBasisConfig | SampleDeclarationConfig | SampleEsiBasisConfig | SelectionFromOptionsConfig | ShipmentBasisConfig | SubTemplateConfig | TextInputConfig | VisitBasisConfig;
 
 export type FieldDependency = {
   __typename?: 'FieldDependency';
@@ -644,6 +682,7 @@ export type InstitutionsFilter = {
 
 export type Instrument = {
   __typename?: 'Instrument';
+  beamlineManager: BasicUserDetails;
   description: Scalars['String'];
   id: Scalars['Int'];
   managerUserId: Scalars['Int'];
@@ -661,6 +700,7 @@ export type InstrumentResponseWrap = {
 export type InstrumentWithAvailabilityTime = {
   __typename?: 'InstrumentWithAvailabilityTime';
   availabilityTime: Maybe<Scalars['Int']>;
+  beamlineManager: BasicUserDetails;
   description: Scalars['String'];
   id: Scalars['Int'];
   managerUserId: Scalars['Int'];
@@ -683,6 +723,12 @@ export type IntervalConfig = {
   small_label: Scalars['String'];
   tooltip: Scalars['String'];
   units: Maybe<Array<Scalars['String']>>;
+};
+
+export type LogoutTokenWrap = {
+  __typename?: 'LogoutTokenWrap';
+  rejection: Maybe<Rejection>;
+  token: Maybe<Scalars['String']>;
 };
 
 export type LostTime = {
@@ -734,7 +780,6 @@ export type Mutation = {
   assignSepReviewersToProposal: SepResponseWrap;
   assignToScheduledEvents: Scalars['Boolean'];
   changeProposalsStatus: SuccessResponseWrap;
-  checkExternalToken: CheckExternalTokenWrap;
   cloneGenericTemplate: GenericTemplateResponseWrap;
   cloneProposals: ProposalsResponseWrap;
   cloneSample: SampleResponseWrap;
@@ -745,6 +790,7 @@ export type Mutation = {
   createCall: CallResponseWrap;
   createEquipment: EquipmentResponseWrap;
   createEsi: EsiResponseWrap;
+  createFeedback: FeedbackResponseWrap;
   createGenericTemplate: GenericTemplateResponseWrap;
   createInstitution: InstitutionResponseWrap;
   createInstrument: InstrumentResponseWrap;
@@ -769,6 +815,7 @@ export type Mutation = {
   deleteApiAccessToken: SuccessResponseWrap;
   deleteCall: CallResponseWrap;
   deleteEquipmentAssignment: Scalars['Boolean'];
+  deleteFeedback: FeedbackResponseWrap;
   deleteGenericTemplate: GenericTemplateResponseWrap;
   deleteInstitution: InstitutionResponseWrap;
   deleteInstrument: InstrumentResponseWrap;
@@ -790,10 +837,13 @@ export type Mutation = {
   deleteUser: UserResponseWrap;
   deleteVisit: VisitResponseWrap;
   emailVerification: EmailVerificationResponseWrap;
+  externalTokenLogin: ExternalTokenLoginWrap;
   finalizeProposalBooking: ProposalBookingResponseWrap;
   finalizeScheduledEvent: ScheduledEventResponseWrap;
   getTokenForUser: TokenResponseWrap;
+  importProposal: ProposalResponseWrap;
   login: TokenResponseWrap;
+  logout: LogoutTokenWrap;
   moveProposalWorkflowStatus: ProposalWorkflowConnectionResponseWrap;
   notifyProposal: ProposalResponseWrap;
   prepareDB: PrepareDbResponseWrap;
@@ -829,6 +879,7 @@ export type Mutation = {
   updateEquipment: EquipmentResponseWrap;
   updateEquipmentOwner: Scalars['Boolean'];
   updateEsi: EsiResponseWrap;
+  updateFeedback: FeedbackResponseWrap;
   updateGenericTemplate: GenericTemplateResponseWrap;
   updateInstitution: InstitutionResponseWrap;
   updateInstrument: InstrumentResponseWrap;
@@ -994,11 +1045,6 @@ export type MutationChangeProposalsStatusArgs = {
 };
 
 
-export type MutationCheckExternalTokenArgs = {
-  externalToken: Scalars['String'];
-};
-
-
 export type MutationCloneGenericTemplateArgs = {
   genericTemplateId: Scalars['Int'];
   title?: Maybe<Scalars['String']>;
@@ -1050,6 +1096,11 @@ export type MutationCreateEquipmentArgs = {
 
 
 export type MutationCreateEsiArgs = {
+  scheduledEventId: Scalars['Int'];
+};
+
+
+export type MutationCreateFeedbackArgs = {
   scheduledEventId: Scalars['Int'];
 };
 
@@ -1222,6 +1273,11 @@ export type MutationDeleteEquipmentAssignmentArgs = {
 };
 
 
+export type MutationDeleteFeedbackArgs = {
+  feedbackId: Scalars['Int'];
+};
+
+
 export type MutationDeleteGenericTemplateArgs = {
   genericTemplateId: Scalars['Int'];
 };
@@ -1329,6 +1385,11 @@ export type MutationEmailVerificationArgs = {
 };
 
 
+export type MutationExternalTokenLoginArgs = {
+  externalToken: Scalars['String'];
+};
+
+
 export type MutationFinalizeProposalBookingArgs = {
   action: ProposalBookingFinalizeAction;
   id: Scalars['Int'];
@@ -1345,9 +1406,25 @@ export type MutationGetTokenForUserArgs = {
 };
 
 
+export type MutationImportProposalArgs = {
+  abstract?: Maybe<Scalars['String']>;
+  callId: Scalars['Int'];
+  proposerId?: Maybe<Scalars['Int']>;
+  referenceNumber: Scalars['Int'];
+  submitterId: Scalars['Int'];
+  title?: Maybe<Scalars['String']>;
+  users?: Maybe<Array<Scalars['Int']>>;
+};
+
+
 export type MutationLoginArgs = {
   email: Scalars['String'];
   password: Scalars['String'];
+};
+
+
+export type MutationLogoutArgs = {
+  token: Scalars['String'];
 };
 
 
@@ -1541,6 +1618,12 @@ export type MutationUpdateEquipmentOwnerArgs = {
 export type MutationUpdateEsiArgs = {
   esiId: Scalars['Int'];
   isSubmitted?: Maybe<Scalars['Boolean']>;
+};
+
+
+export type MutationUpdateFeedbackArgs = {
+  feedbackId: Scalars['Int'];
+  status?: Maybe<FeedbackStatus>;
 };
 
 
@@ -2034,6 +2117,7 @@ export type ProposalView = {
   finalStatus: Maybe<ProposalEndStatus>;
   instrumentId: Maybe<Scalars['Int']>;
   instrumentName: Maybe<Scalars['String']>;
+  managementTimeAllocation: Maybe<Scalars['Int']>;
   notified: Scalars['Boolean'];
   primaryKey: Scalars['Int'];
   proposalId: Scalars['String'];
@@ -2047,7 +2131,7 @@ export type ProposalView = {
   statusName: Scalars['String'];
   submitted: Scalars['Boolean'];
   technicalStatus: Maybe<TechnicalReviewStatus>;
-  timeAllocation: Maybe<Scalars['Int']>;
+  technicalTimeAllocation: Maybe<Scalars['Int']>;
   title: Scalars['String'];
 };
 
@@ -2140,6 +2224,8 @@ export type Query = {
   eventLogs: Maybe<Array<EventLog>>;
   factoryVersion: Scalars['String'];
   features: Array<Feature>;
+  feedback: Maybe<Feedback>;
+  feedbacks: Array<Feedback>;
   fileMetadata: Maybe<Array<FileMetadata>>;
   genericTemplate: Maybe<GenericTemplate>;
   genericTemplates: Maybe<Array<GenericTemplate>>;
@@ -2291,6 +2377,16 @@ export type QueryEsiArgs = {
 export type QueryEventLogsArgs = {
   changedObjectId: Scalars['String'];
   eventType: Scalars['String'];
+};
+
+
+export type QueryFeedbackArgs = {
+  feedbackId: Scalars['Int'];
+};
+
+
+export type QueryFeedbacksArgs = {
+  filter?: Maybe<FeedbacksFilter>;
 };
 
 
@@ -2906,6 +3002,7 @@ export type ScheduledEvent = {
   equipments: Array<EquipmentWithAssignmentStatus>;
   id: Scalars['Int'];
   instrument: Maybe<Instrument>;
+  localContact: Maybe<User>;
   proposalBooking: Maybe<ProposalBooking>;
   proposalBookingId: Maybe<Scalars['Int']>;
   scheduledBy: Maybe<User>;
@@ -2927,8 +3024,10 @@ export type ScheduledEventCore = {
   bookingType: ScheduledEventBookingType;
   endsAt: Scalars['TzLessDateTime'];
   esi: Maybe<ExperimentSafetyInput>;
+  feedback: Maybe<Feedback>;
   id: Scalars['Int'];
   startsAt: Scalars['TzLessDateTime'];
+  status: ProposalBookingStatusCore;
   visit: Maybe<Visit>;
 };
 
@@ -3144,6 +3243,7 @@ export type TemplateCategory = {
 };
 
 export enum TemplateCategoryId {
+  FEEDBACK = 'FEEDBACK',
   GENERIC_TEMPLATE = 'GENERIC_TEMPLATE',
   PROPOSAL_QUESTIONARY = 'PROPOSAL_QUESTIONARY',
   SAMPLE_DECLARATION = 'SAMPLE_DECLARATION',
@@ -3158,6 +3258,7 @@ export type TemplateGroup = {
 };
 
 export enum TemplateGroupId {
+  FEEDBACK = 'FEEDBACK',
   GENERIC_TEMPLATE = 'GENERIC_TEMPLATE',
   PROPOSAL = 'PROPOSAL',
   PROPOSAL_ESI = 'PROPOSAL_ESI',
@@ -3270,6 +3371,7 @@ export type UpdateCallInput = {
   startNotify: Scalars['DateTime'];
   startReview: Scalars['DateTime'];
   startSEPReview?: Maybe<Scalars['DateTime']>;
+  submissionMessage?: Maybe<Scalars['String']>;
   surveyComment: Scalars['String'];
   templateId: Scalars['Int'];
   title?: Maybe<Scalars['String']>;
@@ -3302,6 +3404,7 @@ export type UpdateProposalWorkflowInput = {
 
 export type UpdateScheduledEventInput = {
   endsAt: Scalars['TzLessDateTime'];
+  localContact?: Maybe<Scalars['Int']>;
   scheduledEventId: Scalars['Int'];
   startsAt: Scalars['TzLessDateTime'];
 };
@@ -3781,10 +3884,20 @@ export type GetProposalBookingQuery = (
       & { scheduledBy: Maybe<(
         { __typename?: 'User' }
         & Pick<User, 'id' | 'firstname' | 'lastname'>
+      )>, localContact: Maybe<(
+        { __typename?: 'User' }
+        & Pick<User, 'id' | 'firstname' | 'lastname'>
       )> }
     )>, instrument: Maybe<(
       { __typename?: 'Instrument' }
       & Pick<Instrument, 'id' | 'name'>
+      & { beamlineManager: (
+        { __typename?: 'BasicUserDetails' }
+        & Pick<BasicUserDetails, 'id' | 'firstname' | 'lastname' | 'organisation'>
+      ), scientists: Array<(
+        { __typename?: 'BasicUserDetails' }
+        & Pick<BasicUserDetails, 'id' | 'firstname' | 'lastname' | 'organisation'>
+      )> }
     )> }
   )> }
 );
@@ -3902,6 +4015,9 @@ export type GetEquipmentScheduledEventsQuery = (
       )>, scheduledBy: Maybe<(
         { __typename?: 'User' }
         & Pick<User, 'id' | 'firstname' | 'lastname'>
+      )>, localContact: Maybe<(
+        { __typename?: 'User' }
+        & Pick<User, 'id' | 'firstname' | 'lastname'>
       )> }
     )> }
   )> }
@@ -3918,6 +4034,9 @@ export type GetProposalBookingScheduledEventsQuery = (
     { __typename?: 'ScheduledEvent' }
     & Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt' | 'bookingType' | 'status' | 'description'>
     & { scheduledBy: Maybe<(
+      { __typename?: 'User' }
+      & Pick<User, 'id' | 'firstname' | 'lastname'>
+    )>, localContact: Maybe<(
       { __typename?: 'User' }
       & Pick<User, 'id' | 'firstname' | 'lastname'>
     )> }
@@ -3997,6 +4116,9 @@ export type GetScheduledEventsQuery = (
     )>, scheduledBy: Maybe<(
       { __typename?: 'User' }
       & Pick<User, 'firstname' | 'lastname'>
+    )>, localContact: Maybe<(
+      { __typename?: 'User' }
+      & Pick<User, 'firstname' | 'lastname'>
     )>, proposalBooking: Maybe<(
       { __typename?: 'ProposalBooking' }
       & Pick<ProposalBooking, 'id' | 'createdAt' | 'updatedAt' | 'status' | 'allocatedTime'>
@@ -4061,6 +4183,10 @@ export type UpdateScheduledEventMutation = (
     & { scheduledEvent: Maybe<(
       { __typename?: 'ScheduledEvent' }
       & Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt'>
+      & { localContact: Maybe<(
+        { __typename?: 'User' }
+        & Pick<User, 'firstname' | 'lastname'>
+      )> }
     )> }
   ) }
 );
@@ -4390,12 +4516,29 @@ export const GetProposalBookingDocument = gql`
         firstname
         lastname
       }
+      localContact {
+        id
+        firstname
+        lastname
+      }
       status
       description
     }
     instrument {
       id
       name
+      beamlineManager {
+        id
+        firstname
+        lastname
+        organisation
+      }
+      scientists {
+        id
+        firstname
+        lastname
+        organisation
+      }
     }
     createdAt
     updatedAt
@@ -4498,6 +4641,11 @@ export const GetEquipmentScheduledEventsDocument = gql`
         firstname
         lastname
       }
+      localContact {
+        id
+        firstname
+        lastname
+      }
     }
   }
 }
@@ -4510,6 +4658,11 @@ export const GetProposalBookingScheduledEventsDocument = gql`
     endsAt
     bookingType
     scheduledBy {
+      id
+      firstname
+      lastname
+    }
+    localContact {
       id
       firstname
       lastname
@@ -4604,6 +4757,10 @@ export const GetScheduledEventsDocument = gql`
       firstname
       lastname
     }
+    localContact {
+      firstname
+      lastname
+    }
     proposalBooking {
       id
       createdAt
@@ -4668,6 +4825,10 @@ export const UpdateScheduledEventDocument = gql`
       id
       startsAt
       endsAt
+      localContact {
+        firstname
+        lastname
+      }
     }
   }
 }

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -54,7 +54,6 @@ export type AddTechnicalReviewInput = {
 };
 
 export type AddUserRoleResponseWrap = {
-  __typename?: 'AddUserRoleResponseWrap';
   rejection: Maybe<Rejection>;
   success: Maybe<Scalars['Boolean']>;
 };
@@ -65,7 +64,6 @@ export enum AllocationTimeUnits {
 }
 
 export type Answer = {
-  __typename?: 'Answer';
   answerId: Maybe<Scalars['Int']>;
   config: FieldConfig;
   dependencies: Array<FieldDependency>;
@@ -77,7 +75,6 @@ export type Answer = {
 };
 
 export type AnswerBasic = {
-  __typename?: 'AnswerBasic';
   answer: Scalars['IntStringDateBoolArray'];
   answerId: Maybe<Scalars['Int']>;
   createdAt: Scalars['DateTime'];
@@ -91,7 +88,6 @@ export type AnswerInput = {
 };
 
 export type ApiAccessTokenResponseWrap = {
-  __typename?: 'ApiAccessTokenResponseWrap';
   apiAccessToken: Maybe<PermissionsWithAccessToken>;
   rejection: Maybe<Rejection>;
 };
@@ -114,19 +110,16 @@ export type AssignInstrumentsToCallInput = {
 };
 
 export type AuthJwtApiTokenPayload = {
-  __typename?: 'AuthJwtApiTokenPayload';
   accessTokenId: Scalars['String'];
 };
 
 export type AuthJwtPayload = {
-  __typename?: 'AuthJwtPayload';
   currentRole: Role;
   roles: Array<Role>;
   user: User;
 };
 
 export type BasicUserDetails = {
-  __typename?: 'BasicUserDetails';
   created: Maybe<Scalars['DateTime']>;
   firstname: Scalars['String'];
   id: Scalars['Int'];
@@ -138,20 +131,17 @@ export type BasicUserDetails = {
 };
 
 export type BasicUserDetailsResponseWrap = {
-  __typename?: 'BasicUserDetailsResponseWrap';
   rejection: Maybe<Rejection>;
   user: Maybe<BasicUserDetails>;
 };
 
 export type BooleanConfig = {
-  __typename?: 'BooleanConfig';
   required: Scalars['Boolean'];
   small_label: Scalars['String'];
   tooltip: Scalars['String'];
 };
 
 export type Call = {
-  __typename?: 'Call';
   allocationTimeUnit: AllocationTimeUnits;
   cycleComment: Scalars['String'];
   description: Maybe<Scalars['String']>;
@@ -183,7 +173,6 @@ export type Call = {
 };
 
 export type CallResponseWrap = {
-  __typename?: 'CallResponseWrap';
   call: Maybe<Call>;
   rejection: Maybe<Rejection>;
 };
@@ -211,6 +200,17 @@ export type ConfirmEquipmentAssignmentInput = {
   newStatus: EquipmentAssignmentStatus;
   scheduledEventId: Scalars['Int'];
 };
+
+export type ConflictResolution = {
+  questionId: Scalars['String'];
+  strategy: ConflictResolutionStrategy;
+};
+
+export enum ConflictResolutionStrategy {
+  UNRESOLVED = 'UNRESOLVED',
+  USE_EXISTING = 'USE_EXISTING',
+  USE_NEW = 'USE_NEW'
+}
 
 export type CreateApiAccessTokenInput = {
   accessPermissions: Scalars['String'];
@@ -254,7 +254,6 @@ export type CreateProposalWorkflowInput = {
 };
 
 export type CreateUserByEmailInviteResponseWrap = {
-  __typename?: 'CreateUserByEmailInviteResponseWrap';
   id: Maybe<Scalars['Int']>;
   rejection: Maybe<Rejection>;
 };
@@ -282,7 +281,6 @@ export enum DataType {
 }
 
 export type DateConfig = {
-  __typename?: 'DateConfig';
   defaultDate: Maybe<Scalars['String']>;
   includeTime: Scalars['Boolean'];
   maxDate: Maybe<Scalars['String']>;
@@ -294,7 +292,6 @@ export type DateConfig = {
 
 
 export type DbStat = {
-  __typename?: 'DbStat';
   state: Maybe<Scalars['String']>;
   total: Scalars['Float'];
 };
@@ -331,26 +328,22 @@ export enum DependenciesLogicOperator {
 }
 
 export type EmailVerificationResponseWrap = {
-  __typename?: 'EmailVerificationResponseWrap';
   rejection: Maybe<Rejection>;
   success: Maybe<Scalars['Boolean']>;
 };
 
 export type EmbellishmentConfig = {
-  __typename?: 'EmbellishmentConfig';
   html: Scalars['String'];
   omitFromPdf: Scalars['Boolean'];
   plain: Scalars['String'];
 };
 
 export type Entry = {
-  __typename?: 'Entry';
   id: Scalars['Int'];
   value: Scalars['String'];
 };
 
 export type Equipment = {
-  __typename?: 'Equipment';
   autoAccept: Scalars['Boolean'];
   createdAt: Scalars['DateTime'];
   description: Maybe<Scalars['String']>;
@@ -385,7 +378,6 @@ export type EquipmentInput = {
 };
 
 export type EquipmentResponseWrap = {
-  __typename?: 'EquipmentResponseWrap';
   equipment: Maybe<Equipment>;
   error: Maybe<Scalars['String']>;
 };
@@ -396,7 +388,6 @@ export type EquipmentResponsibleInput = {
 };
 
 export type EquipmentWithAssignmentStatus = {
-  __typename?: 'EquipmentWithAssignmentStatus';
   autoAccept: Scalars['Boolean'];
   createdAt: Scalars['DateTime'];
   description: Maybe<Scalars['String']>;
@@ -418,7 +409,6 @@ export type EquipmentWithAssignmentStatusEventsArgs = {
 };
 
 export type EsiResponseWrap = {
-  __typename?: 'EsiResponseWrap';
   esi: Maybe<ExperimentSafetyInput>;
   rejection: Maybe<Rejection>;
 };
@@ -485,7 +475,6 @@ export enum Event {
 }
 
 export type EventLog = {
-  __typename?: 'EventLog';
   changedBy: User;
   changedObjectId: Scalars['String'];
   eventTStamp: Scalars['DateTime'];
@@ -495,7 +484,6 @@ export type EventLog = {
 };
 
 export type ExperimentSafetyInput = {
-  __typename?: 'ExperimentSafetyInput';
   created: Scalars['DateTime'];
   creatorId: Scalars['Int'];
   id: Scalars['Int'];
@@ -508,13 +496,11 @@ export type ExperimentSafetyInput = {
 };
 
 export type ExternalTokenLoginWrap = {
-  __typename?: 'ExternalTokenLoginWrap';
   rejection: Maybe<Rejection>;
   token: Maybe<Scalars['String']>;
 };
 
 export type Feature = {
-  __typename?: 'Feature';
   description: Scalars['String'];
   id: FeatureId;
   isEnabled: Scalars['Boolean'];
@@ -529,7 +515,6 @@ export enum FeatureId {
 }
 
 export type Feedback = {
-  __typename?: 'Feedback';
   createdAt: Scalars['DateTime'];
   creatorId: Scalars['Int'];
   id: Scalars['Int'];
@@ -541,14 +526,12 @@ export type Feedback = {
 };
 
 export type FeedbackBasisConfig = {
-  __typename?: 'FeedbackBasisConfig';
   required: Scalars['Boolean'];
   small_label: Scalars['String'];
   tooltip: Scalars['String'];
 };
 
 export type FeedbackResponseWrap = {
-  __typename?: 'FeedbackResponseWrap';
   feedback: Maybe<Feedback>;
   rejection: Maybe<Rejection>;
 };
@@ -564,7 +547,6 @@ export type FeedbacksFilter = {
 };
 
 export type FieldCondition = {
-  __typename?: 'FieldCondition';
   condition: EvaluatorOperator;
   params: Scalars['IntStringDateBoolArray'];
 };
@@ -577,7 +559,6 @@ export type FieldConditionInput = {
 export type FieldConfig = BooleanConfig | DateConfig | EmbellishmentConfig | FeedbackBasisConfig | FileUploadConfig | GenericTemplateBasisConfig | IntervalConfig | NumberInputConfig | ProposalBasisConfig | ProposalEsiBasisConfig | RichTextInputConfig | SampleBasisConfig | SampleDeclarationConfig | SampleEsiBasisConfig | SelectionFromOptionsConfig | ShipmentBasisConfig | SubTemplateConfig | TextInputConfig | VisitBasisConfig;
 
 export type FieldDependency = {
-  __typename?: 'FieldDependency';
   condition: FieldCondition;
   dependencyId: Scalars['String'];
   dependencyNaturalKey: Scalars['String'];
@@ -590,13 +571,11 @@ export type FieldDependencyInput = {
 };
 
 export type Fields = {
-  __typename?: 'Fields';
   countries: Array<Entry>;
   nationalities: Array<Entry>;
 };
 
 export type FileMetadata = {
-  __typename?: 'FileMetadata';
   createdDate: Scalars['DateTime'];
   fileId: Scalars['String'];
   mimeType: Scalars['String'];
@@ -605,7 +584,6 @@ export type FileMetadata = {
 };
 
 export type FileUploadConfig = {
-  __typename?: 'FileUploadConfig';
   file_type: Array<Scalars['String']>;
   max_files: Scalars['Int'];
   required: Scalars['Boolean'];
@@ -619,7 +597,6 @@ export type FinalizeScheduledEventInput = {
 };
 
 export type GenericTemplate = {
-  __typename?: 'GenericTemplate';
   created: Scalars['DateTime'];
   creatorId: Scalars['Int'];
   id: Scalars['Int'];
@@ -632,13 +609,11 @@ export type GenericTemplate = {
 };
 
 export type GenericTemplateBasisConfig = {
-  __typename?: 'GenericTemplateBasisConfig';
   questionLabel: Scalars['String'];
   titlePlaceholder: Scalars['String'];
 };
 
 export type GenericTemplateResponseWrap = {
-  __typename?: 'GenericTemplateResponseWrap';
   genericTemplate: Maybe<GenericTemplate>;
   rejection: Maybe<Rejection>;
 };
@@ -653,7 +628,6 @@ export type GenericTemplatesFilter = {
 };
 
 export type HealthStats = {
-  __typename?: 'HealthStats';
   dbStats: Array<DbStat>;
   message: Scalars['String'];
 };
@@ -664,14 +638,12 @@ export type IndexWithGroupId = {
 };
 
 export type Institution = {
-  __typename?: 'Institution';
   id: Scalars['Int'];
   name: Scalars['String'];
   verified: Scalars['Boolean'];
 };
 
 export type InstitutionResponseWrap = {
-  __typename?: 'InstitutionResponseWrap';
   institution: Maybe<Institution>;
   rejection: Maybe<Rejection>;
 };
@@ -681,7 +653,6 @@ export type InstitutionsFilter = {
 };
 
 export type Instrument = {
-  __typename?: 'Instrument';
   beamlineManager: BasicUserDetails;
   description: Scalars['String'];
   id: Scalars['Int'];
@@ -692,13 +663,11 @@ export type Instrument = {
 };
 
 export type InstrumentResponseWrap = {
-  __typename?: 'InstrumentResponseWrap';
   instrument: Maybe<Instrument>;
   rejection: Maybe<Rejection>;
 };
 
 export type InstrumentWithAvailabilityTime = {
-  __typename?: 'InstrumentWithAvailabilityTime';
   availabilityTime: Maybe<Scalars['Int']>;
   beamlineManager: BasicUserDetails;
   description: Scalars['String'];
@@ -711,14 +680,12 @@ export type InstrumentWithAvailabilityTime = {
 };
 
 export type InstrumentsQueryResult = {
-  __typename?: 'InstrumentsQueryResult';
   instruments: Array<Instrument>;
   totalCount: Scalars['Int'];
 };
 
 
 export type IntervalConfig = {
-  __typename?: 'IntervalConfig';
   required: Scalars['Boolean'];
   small_label: Scalars['String'];
   tooltip: Scalars['String'];
@@ -726,13 +693,11 @@ export type IntervalConfig = {
 };
 
 export type LogoutTokenWrap = {
-  __typename?: 'LogoutTokenWrap';
   rejection: Maybe<Rejection>;
   token: Maybe<Scalars['String']>;
 };
 
 export type LostTime = {
-  __typename?: 'LostTime';
   createdAt: Scalars['DateTime'];
   endsAt: Scalars['TzLessDateTime'];
   id: Scalars['Int'];
@@ -743,7 +708,6 @@ export type LostTime = {
 };
 
 export type LostTimeResponseWrap = {
-  __typename?: 'LostTimeResponseWrap';
   error: Maybe<Scalars['String']>;
   lostTime: Maybe<LostTime>;
 };
@@ -755,7 +719,6 @@ export type MoveProposalWorkflowStatusInput = {
 };
 
 export type Mutation = {
-  __typename?: 'Mutation';
   activateProposalBooking: ProposalBookingResponseWrap;
   activateScheduledEvent: ScheduledEventResponseWrap;
   addClientLog: SuccessResponseWrap;
@@ -842,6 +805,7 @@ export type Mutation = {
   finalizeScheduledEvent: ScheduledEventResponseWrap;
   getTokenForUser: TokenResponseWrap;
   importProposal: ProposalResponseWrap;
+  importTemplate: TemplateResponseWrap;
   login: TokenResponseWrap;
   logout: LogoutTokenWrap;
   moveProposalWorkflowStatus: ProposalWorkflowConnectionResponseWrap;
@@ -904,6 +868,7 @@ export type Mutation = {
   updateUserRoles: UserResponseWrap;
   updateVisit: VisitResponseWrap;
   updateVisitRegistration: VisitRegistrationResponseWrap;
+  validateTemplateImport: TemplateImportWithValidationWrap;
 };
 
 
@@ -1417,6 +1382,12 @@ export type MutationImportProposalArgs = {
 };
 
 
+export type MutationImportTemplateArgs = {
+  conflictResolutions: Array<ConflictResolution>;
+  templateAsJson: Scalars['String'];
+};
+
+
 export type MutationLoginArgs = {
   email: Scalars['String'];
   password: Scalars['String'];
@@ -1818,6 +1789,11 @@ export type MutationUpdateVisitRegistrationArgs = {
   visitId: Scalars['Int'];
 };
 
+
+export type MutationValidateTemplateImportArgs = {
+  templateAsJson: Scalars['String'];
+};
+
 export type NewScheduledEventInput = {
   bookingType: ScheduledEventBookingType;
   description?: Maybe<Scalars['String']>;
@@ -1828,7 +1804,6 @@ export type NewScheduledEventInput = {
 };
 
 export type NextProposalStatus = {
-  __typename?: 'NextProposalStatus';
   description: Maybe<Scalars['String']>;
   id: Maybe<Scalars['Int']>;
   isDefault: Maybe<Scalars['Boolean']>;
@@ -1837,13 +1812,11 @@ export type NextProposalStatus = {
 };
 
 export type NextProposalStatusResponseWrap = {
-  __typename?: 'NextProposalStatusResponseWrap';
   nextProposalStatus: Maybe<NextProposalStatus>;
   rejection: Maybe<Rejection>;
 };
 
 export type NumberInputConfig = {
-  __typename?: 'NumberInputConfig';
   numberValueConstraint: Maybe<NumberValueConstraint>;
   required: Scalars['Boolean'];
   small_label: Scalars['String'];
@@ -1858,7 +1831,6 @@ export enum NumberValueConstraint {
 }
 
 export type OrcIdInformation = {
-  __typename?: 'OrcIDInformation';
   firstname: Maybe<Scalars['String']>;
   lastname: Maybe<Scalars['String']>;
   orcid: Maybe<Scalars['String']>;
@@ -1868,7 +1840,6 @@ export type OrcIdInformation = {
 };
 
 export type Page = {
-  __typename?: 'Page';
   content: Maybe<Scalars['String']>;
   id: Scalars['Int'];
 };
@@ -1883,13 +1854,11 @@ export enum PageName {
 }
 
 export type PageResponseWrap = {
-  __typename?: 'PageResponseWrap';
   page: Maybe<Page>;
   rejection: Maybe<Rejection>;
 };
 
 export type PermissionsWithAccessToken = {
-  __typename?: 'PermissionsWithAccessToken';
   accessPermissions: Scalars['String'];
   accessToken: Scalars['String'];
   id: Scalars['String'];
@@ -1897,13 +1866,11 @@ export type PermissionsWithAccessToken = {
 };
 
 export type PrepareDbResponseWrap = {
-  __typename?: 'PrepareDBResponseWrap';
   log: Maybe<Scalars['String']>;
   rejection: Maybe<Rejection>;
 };
 
 export type Proposal = {
-  __typename?: 'Proposal';
   abstract: Scalars['String'];
   call: Maybe<Call>;
   callId: Scalars['Int'];
@@ -1950,12 +1917,10 @@ export type ProposalProposalBookingCoreArgs = {
 };
 
 export type ProposalBasisConfig = {
-  __typename?: 'ProposalBasisConfig';
   tooltip: Scalars['String'];
 };
 
 export type ProposalBooking = {
-  __typename?: 'ProposalBooking';
   allocatedTime: Scalars['Int'];
   call: Maybe<Call>;
   createdAt: Scalars['DateTime'];
@@ -1973,7 +1938,6 @@ export type ProposalBookingScheduledEventsArgs = {
 };
 
 export type ProposalBookingCore = {
-  __typename?: 'ProposalBookingCore';
   id: Scalars['Int'];
   scheduledEvents: Array<ScheduledEventCore>;
 };
@@ -1993,7 +1957,6 @@ export enum ProposalBookingFinalizeAction {
 }
 
 export type ProposalBookingResponseWrap = {
-  __typename?: 'ProposalBookingResponseWrap';
   error: Maybe<Scalars['String']>;
   proposalBooking: Maybe<ProposalBooking>;
 };
@@ -2025,12 +1988,10 @@ export enum ProposalEndStatus {
 }
 
 export type ProposalEsiBasisConfig = {
-  __typename?: 'ProposalEsiBasisConfig';
   tooltip: Scalars['String'];
 };
 
 export type ProposalEvent = {
-  __typename?: 'ProposalEvent';
   description: Maybe<Scalars['String']>;
   name: Event;
 };
@@ -2064,13 +2025,11 @@ export enum ProposalPublicStatus {
 }
 
 export type ProposalResponseWrap = {
-  __typename?: 'ProposalResponseWrap';
   proposal: Maybe<Proposal>;
   rejection: Maybe<Rejection>;
 };
 
 export type ProposalStatus = {
-  __typename?: 'ProposalStatus';
   description: Scalars['String'];
   id: Scalars['Int'];
   isDefault: Scalars['Boolean'];
@@ -2079,19 +2038,16 @@ export type ProposalStatus = {
 };
 
 export type ProposalStatusChangingEventResponseWrap = {
-  __typename?: 'ProposalStatusChangingEventResponseWrap';
   rejection: Maybe<Rejection>;
   statusChangingEvents: Maybe<Array<StatusChangingEvent>>;
 };
 
 export type ProposalStatusResponseWrap = {
-  __typename?: 'ProposalStatusResponseWrap';
   proposalStatus: Maybe<ProposalStatus>;
   rejection: Maybe<Rejection>;
 };
 
 export type ProposalTemplate = {
-  __typename?: 'ProposalTemplate';
   callCount: Scalars['Int'];
   complementaryQuestions: Array<Question>;
   description: Maybe<Scalars['String']>;
@@ -2111,7 +2067,6 @@ export type ProposalTemplatesFilter = {
 };
 
 export type ProposalView = {
-  __typename?: 'ProposalView';
   allocationTimeUnit: AllocationTimeUnits;
   callId: Scalars['Int'];
   callShortCode: Maybe<Scalars['String']>;
@@ -2131,13 +2086,14 @@ export type ProposalView = {
   statusId: Scalars['Int'];
   statusName: Scalars['String'];
   submitted: Scalars['Boolean'];
+  technicalReviewAssignee: Maybe<Scalars['Int']>;
+  technicalReviewSubmitted: Maybe<Scalars['Int']>;
   technicalStatus: Maybe<TechnicalReviewStatus>;
   technicalTimeAllocation: Maybe<Scalars['Int']>;
   title: Scalars['String'];
 };
 
 export type ProposalWorkflow = {
-  __typename?: 'ProposalWorkflow';
   description: Scalars['String'];
   id: Scalars['Int'];
   name: Scalars['String'];
@@ -2145,7 +2101,6 @@ export type ProposalWorkflow = {
 };
 
 export type ProposalWorkflowConnection = {
-  __typename?: 'ProposalWorkflowConnection';
   droppableGroupId: Scalars['String'];
   id: Scalars['Int'];
   nextProposalStatusId: Maybe<Scalars['Int']>;
@@ -2158,20 +2113,17 @@ export type ProposalWorkflowConnection = {
 };
 
 export type ProposalWorkflowConnectionGroup = {
-  __typename?: 'ProposalWorkflowConnectionGroup';
   connections: Array<ProposalWorkflowConnection>;
   groupId: Scalars['String'];
   parentGroupId: Maybe<Scalars['String']>;
 };
 
 export type ProposalWorkflowConnectionResponseWrap = {
-  __typename?: 'ProposalWorkflowConnectionResponseWrap';
   proposalWorkflowConnection: Maybe<ProposalWorkflowConnection>;
   rejection: Maybe<Rejection>;
 };
 
 export type ProposalWorkflowResponseWrap = {
-  __typename?: 'ProposalWorkflowResponseWrap';
   proposalWorkflow: Maybe<ProposalWorkflow>;
   rejection: Maybe<Rejection>;
 };
@@ -2187,25 +2139,26 @@ export type ProposalsFilter = {
 };
 
 export type ProposalsQueryResult = {
-  __typename?: 'ProposalsQueryResult';
   proposals: Array<Proposal>;
   totalCount: Scalars['Int'];
 };
 
 export type ProposalsResponseWrap = {
-  __typename?: 'ProposalsResponseWrap';
   proposals: Array<Proposal>;
   rejection: Maybe<Rejection>;
 };
 
+export type ProposalsViewResult = {
+  proposals: Array<ProposalView>;
+  totalCount: Scalars['Int'];
+};
+
 export type QueriesAndMutations = {
-  __typename?: 'QueriesAndMutations';
   mutations: Array<Scalars['String']>;
   queries: Array<Scalars['String']>;
 };
 
 export type Query = {
-  __typename?: 'Query';
   accessTokenAndPermissions: Maybe<PermissionsWithAccessToken>;
   activeTemplateId: Maybe<Scalars['Int']>;
   allAccessTokensAndPermissions: Maybe<Array<PermissionsWithAccessToken>>;
@@ -2239,7 +2192,7 @@ export type Query = {
   instrumentProposalBookings: Array<ProposalBooking>;
   instrumentScientistHasAccess: Maybe<Scalars['Boolean']>;
   instrumentScientistHasInstrument: Maybe<Scalars['Boolean']>;
-  instrumentScientistProposals: Maybe<ProposalsQueryResult>;
+  instrumentScientistProposals: Maybe<ProposalsViewResult>;
   instruments: Maybe<InstrumentsQueryResult>;
   instrumentsBySep: Maybe<Array<InstrumentWithAvailabilityTime>>;
   isNaturalKeyPresent: Maybe<Scalars['Boolean']>;
@@ -2677,7 +2630,6 @@ export type QueryVisitsArgs = {
 };
 
 export type Question = {
-  __typename?: 'Question';
   categoryId: TemplateCategoryId;
   config: FieldConfig;
   dataType: DataType;
@@ -2685,6 +2637,19 @@ export type Question = {
   naturalKey: Scalars['String'];
   question: Scalars['String'];
 };
+
+export type QuestionComparison = {
+  conflictResolutionStrategy: ConflictResolutionStrategy;
+  existingQuestion: Maybe<Question>;
+  newQuestion: Question;
+  status: QuestionComparisonStatus;
+};
+
+export enum QuestionComparisonStatus {
+  DIFFERENT = 'DIFFERENT',
+  NEW = 'NEW',
+  SAME = 'SAME'
+}
 
 export enum QuestionFilterCompareOperator {
   EQUALS = 'EQUALS',
@@ -2702,13 +2667,11 @@ export type QuestionFilterInput = {
 };
 
 export type QuestionResponseWrap = {
-  __typename?: 'QuestionResponseWrap';
   question: Maybe<Question>;
   rejection: Maybe<Rejection>;
 };
 
 export type QuestionTemplateRelation = {
-  __typename?: 'QuestionTemplateRelation';
   config: FieldConfig;
   dependencies: Array<FieldDependency>;
   dependenciesOperator: Maybe<DependenciesLogicOperator>;
@@ -2718,7 +2681,6 @@ export type QuestionTemplateRelation = {
 };
 
 export type QuestionWithUsage = {
-  __typename?: 'QuestionWithUsage';
   answers: Array<AnswerBasic>;
   categoryId: TemplateCategoryId;
   config: FieldConfig;
@@ -2730,7 +2692,6 @@ export type QuestionWithUsage = {
 };
 
 export type Questionary = {
-  __typename?: 'Questionary';
   created: Scalars['DateTime'];
   isCompleted: Scalars['Boolean'];
   questionaryId: Scalars['Int'];
@@ -2739,20 +2700,17 @@ export type Questionary = {
 };
 
 export type QuestionaryResponseWrap = {
-  __typename?: 'QuestionaryResponseWrap';
   questionary: Maybe<Questionary>;
   rejection: Maybe<Rejection>;
 };
 
 export type QuestionaryStep = {
-  __typename?: 'QuestionaryStep';
   fields: Array<Answer>;
   isCompleted: Scalars['Boolean'];
   topic: Topic;
 };
 
 export type QuestionaryStepResponseWrap = {
-  __typename?: 'QuestionaryStepResponseWrap';
   questionaryStep: Maybe<QuestionaryStep>;
   rejection: Maybe<Rejection>;
 };
@@ -2761,11 +2719,11 @@ export type QuestionsFilter = {
   category?: Maybe<TemplateCategoryId>;
   dataType?: Maybe<Array<DataType>>;
   excludeDataType?: Maybe<Array<DataType>>;
+  questionIds?: Maybe<Array<Scalars['String']>>;
   text?: Maybe<Scalars['String']>;
 };
 
 export type Rejection = {
-  __typename?: 'Rejection';
   context: Maybe<Scalars['String']>;
   exception: Maybe<Scalars['String']>;
   reason: Scalars['String'];
@@ -2781,7 +2739,6 @@ export type ReorderSepMeetingDecisionProposalsInput = {
 };
 
 export type Review = {
-  __typename?: 'Review';
   comment: Maybe<Scalars['String']>;
   grade: Maybe<Scalars['Int']>;
   id: Scalars['Int'];
@@ -2793,7 +2750,6 @@ export type Review = {
 };
 
 export type ReviewResponseWrap = {
-  __typename?: 'ReviewResponseWrap';
   rejection: Maybe<Rejection>;
   review: Maybe<Review>;
 };
@@ -2804,7 +2760,6 @@ export enum ReviewStatus {
 }
 
 export type ReviewWithNextProposalStatus = {
-  __typename?: 'ReviewWithNextProposalStatus';
   comment: Maybe<Scalars['String']>;
   grade: Maybe<Scalars['Int']>;
   id: Scalars['Int'];
@@ -2817,7 +2772,6 @@ export type ReviewWithNextProposalStatus = {
 };
 
 export type ReviewWithNextStatusResponseWrap = {
-  __typename?: 'ReviewWithNextStatusResponseWrap';
   rejection: Maybe<Rejection>;
   review: Maybe<ReviewWithNextProposalStatus>;
 };
@@ -2828,7 +2782,6 @@ export enum ReviewerFilter {
 }
 
 export type RichTextInputConfig = {
-  __typename?: 'RichTextInputConfig';
   max: Maybe<Scalars['Int']>;
   required: Scalars['Boolean'];
   small_label: Scalars['String'];
@@ -2836,14 +2789,12 @@ export type RichTextInputConfig = {
 };
 
 export type Role = {
-  __typename?: 'Role';
   id: Scalars['Int'];
   shortCode: Scalars['String'];
   title: Scalars['String'];
 };
 
 export type Sep = {
-  __typename?: 'SEP';
   active: Scalars['Boolean'];
   code: Scalars['String'];
   description: Scalars['String'];
@@ -2854,7 +2805,6 @@ export type Sep = {
 };
 
 export type SepAssignment = {
-  __typename?: 'SEPAssignment';
   dateAssigned: Scalars['DateTime'];
   dateReassigned: Maybe<Scalars['DateTime']>;
   emailSent: Scalars['Boolean'];
@@ -2869,7 +2819,6 @@ export type SepAssignment = {
 };
 
 export type SepProposal = {
-  __typename?: 'SEPProposal';
   assignments: Maybe<Array<SepAssignment>>;
   dateAssigned: Scalars['DateTime'];
   instrumentSubmitted: Scalars['Boolean'];
@@ -2880,19 +2829,16 @@ export type SepProposal = {
 };
 
 export type SepProposalResponseWrap = {
-  __typename?: 'SEPProposalResponseWrap';
   rejection: Maybe<Rejection>;
   sepProposal: Maybe<SepProposal>;
 };
 
 export type SepResponseWrap = {
-  __typename?: 'SEPResponseWrap';
   rejection: Maybe<Rejection>;
   sep: Maybe<Sep>;
 };
 
 export type SepReviewer = {
-  __typename?: 'SEPReviewer';
   role: Maybe<Role>;
   sepId: Scalars['Int'];
   user: BasicUserDetails;
@@ -2900,13 +2846,11 @@ export type SepReviewer = {
 };
 
 export type SePsQueryResult = {
-  __typename?: 'SEPsQueryResult';
   seps: Array<Sep>;
   totalCount: Scalars['Int'];
 };
 
 export type Sample = {
-  __typename?: 'Sample';
   created: Scalars['DateTime'];
   creatorId: Scalars['Int'];
   id: Scalars['Int'];
@@ -2922,12 +2866,10 @@ export type Sample = {
 };
 
 export type SampleBasisConfig = {
-  __typename?: 'SampleBasisConfig';
   titlePlaceholder: Scalars['String'];
 };
 
 export type SampleDeclarationConfig = {
-  __typename?: 'SampleDeclarationConfig';
   addEntryButtonLabel: Scalars['String'];
   esiTemplateId: Maybe<Scalars['Int']>;
   maxEntries: Maybe<Scalars['Int']>;
@@ -2939,18 +2881,15 @@ export type SampleDeclarationConfig = {
 };
 
 export type SampleEsiBasisConfig = {
-  __typename?: 'SampleEsiBasisConfig';
   tooltip: Scalars['String'];
 };
 
 export type SampleEsiResponseWrap = {
-  __typename?: 'SampleEsiResponseWrap';
   esi: Maybe<SampleExperimentSafetyInput>;
   rejection: Maybe<Rejection>;
 };
 
 export type SampleExperimentSafetyInput = {
-  __typename?: 'SampleExperimentSafetyInput';
   esiId: Scalars['Int'];
   isSubmitted: Scalars['Boolean'];
   questionary: Questionary;
@@ -2960,7 +2899,6 @@ export type SampleExperimentSafetyInput = {
 };
 
 export type SampleResponseWrap = {
-  __typename?: 'SampleResponseWrap';
   rejection: Maybe<Rejection>;
   sample: Maybe<Sample>;
 };
@@ -2993,7 +2931,6 @@ export type SaveSepMeetingDecisionInput = {
 };
 
 export type ScheduledEvent = {
-  __typename?: 'ScheduledEvent';
   bookingType: ScheduledEventBookingType;
   createdAt: Scalars['DateTime'];
   description: Maybe<Scalars['String']>;
@@ -3003,7 +2940,7 @@ export type ScheduledEvent = {
   equipments: Array<EquipmentWithAssignmentStatus>;
   id: Scalars['Int'];
   instrument: Maybe<Instrument>;
-  localContact: Maybe<User>;
+  localContact: Maybe<BasicUserDetails>;
   proposalBooking: Maybe<ProposalBooking>;
   proposalBookingId: Maybe<Scalars['Int']>;
   scheduledBy: Maybe<User>;
@@ -3021,7 +2958,6 @@ export enum ScheduledEventBookingType {
 }
 
 export type ScheduledEventCore = {
-  __typename?: 'ScheduledEventCore';
   bookingType: ScheduledEventBookingType;
   endsAt: Scalars['TzLessDateTime'];
   esi: Maybe<ExperimentSafetyInput>;
@@ -3041,24 +2977,20 @@ export type ScheduledEventFilter = {
 };
 
 export type ScheduledEventResponseWrap = {
-  __typename?: 'ScheduledEventResponseWrap';
   error: Maybe<Scalars['String']>;
   scheduledEvent: Maybe<ScheduledEvent>;
 };
 
 export type ScheduledEventsResponseWrap = {
-  __typename?: 'ScheduledEventsResponseWrap';
   error: Maybe<Scalars['String']>;
   scheduledEvents: Maybe<Array<ScheduledEvent>>;
 };
 
 export type SchedulerConfig = {
-  __typename?: 'SchedulerConfig';
   authRedirect: Scalars['String'];
 };
 
 export type SelectionFromOptionsConfig = {
-  __typename?: 'SelectionFromOptionsConfig';
   isMultipleSelect: Scalars['Boolean'];
   options: Array<Scalars['String']>;
   required: Scalars['Boolean'];
@@ -3068,7 +3000,6 @@ export type SelectionFromOptionsConfig = {
 };
 
 export type SepMeetingDecision = {
-  __typename?: 'SepMeetingDecision';
   commentForManagement: Maybe<Scalars['String']>;
   commentForUser: Maybe<Scalars['String']>;
   proposalPk: Scalars['Int'];
@@ -3079,13 +3010,11 @@ export type SepMeetingDecision = {
 };
 
 export type SepMeetingDecisionResponseWrap = {
-  __typename?: 'SepMeetingDecisionResponseWrap';
   rejection: Maybe<Rejection>;
   sepMeetingDecision: Maybe<SepMeetingDecision>;
 };
 
 export type Settings = {
-  __typename?: 'Settings';
   description: Maybe<Scalars['String']>;
   id: SettingsId;
   settingsValue: Maybe<Scalars['String']>;
@@ -3111,7 +3040,6 @@ export enum SettingsId {
 }
 
 export type Shipment = {
-  __typename?: 'Shipment';
   created: Scalars['DateTime'];
   creatorId: Scalars['Int'];
   externalRef: Maybe<Scalars['String']>;
@@ -3127,14 +3055,12 @@ export type Shipment = {
 };
 
 export type ShipmentBasisConfig = {
-  __typename?: 'ShipmentBasisConfig';
   required: Scalars['Boolean'];
   small_label: Scalars['String'];
   tooltip: Scalars['String'];
 };
 
 export type ShipmentResponseWrap = {
-  __typename?: 'ShipmentResponseWrap';
   rejection: Maybe<Rejection>;
   shipment: Maybe<Shipment>;
 };
@@ -3163,14 +3089,12 @@ export type SimpleLostTimeInput = {
 };
 
 export type StatusChangingEvent = {
-  __typename?: 'StatusChangingEvent';
   proposalWorkflowConnectionId: Scalars['Int'];
   statusChangingEvent: Scalars['String'];
   statusChangingEventId: Scalars['Int'];
 };
 
 export type SubTemplateConfig = {
-  __typename?: 'SubTemplateConfig';
   addEntryButtonLabel: Scalars['String'];
   maxEntries: Maybe<Scalars['Int']>;
   minEntries: Maybe<Scalars['Int']>;
@@ -3195,13 +3119,11 @@ export type SubmitTechnicalReviewInput = {
 };
 
 export type SuccessResponseWrap = {
-  __typename?: 'SuccessResponseWrap';
   isSuccess: Maybe<Scalars['Boolean']>;
   rejection: Maybe<Rejection>;
 };
 
 export type TechnicalReview = {
-  __typename?: 'TechnicalReview';
   comment: Maybe<Scalars['String']>;
   id: Scalars['Int'];
   proposal: Maybe<Proposal>;
@@ -3215,7 +3137,6 @@ export type TechnicalReview = {
 };
 
 export type TechnicalReviewResponseWrap = {
-  __typename?: 'TechnicalReviewResponseWrap';
   rejection: Maybe<Rejection>;
   technicalReview: Maybe<TechnicalReview>;
 };
@@ -3227,7 +3148,6 @@ export enum TechnicalReviewStatus {
 }
 
 export type Template = {
-  __typename?: 'Template';
   complementaryQuestions: Array<Question>;
   description: Maybe<Scalars['String']>;
   group: TemplateGroup;
@@ -3241,7 +3161,6 @@ export type Template = {
 };
 
 export type TemplateCategory = {
-  __typename?: 'TemplateCategory';
   categoryId: TemplateCategoryId;
   name: Scalars['String'];
 };
@@ -3256,7 +3175,6 @@ export enum TemplateCategoryId {
 }
 
 export type TemplateGroup = {
-  __typename?: 'TemplateGroup';
   categoryId: TemplateCategoryId;
   groupId: TemplateGroupId;
 };
@@ -3272,14 +3190,26 @@ export enum TemplateGroupId {
   VISIT_REGISTRATION = 'VISIT_REGISTRATION'
 }
 
+export type TemplateImportWithValidation = {
+  errors: Array<Scalars['String']>;
+  exportDate: Scalars['DateTime'];
+  isValid: Scalars['Boolean'];
+  json: Scalars['String'];
+  questionComparisons: Array<QuestionComparison>;
+  version: Scalars['String'];
+};
+
+export type TemplateImportWithValidationWrap = {
+  rejection: Maybe<Rejection>;
+  validationResult: Maybe<TemplateImportWithValidation>;
+};
+
 export type TemplateResponseWrap = {
-  __typename?: 'TemplateResponseWrap';
   rejection: Maybe<Rejection>;
   template: Maybe<Template>;
 };
 
 export type TemplateStep = {
-  __typename?: 'TemplateStep';
   fields: Array<QuestionTemplateRelation>;
   topic: Topic;
 };
@@ -3291,7 +3221,6 @@ export type TemplatesFilter = {
 };
 
 export type TextInputConfig = {
-  __typename?: 'TextInputConfig';
   htmlQuestion: Maybe<Scalars['String']>;
   isCounterHidden: Scalars['Boolean'];
   isHtmlQuestion: Scalars['Boolean'];
@@ -3307,19 +3236,16 @@ export type TextInputConfig = {
 export type TokenPayloadUnion = AuthJwtApiTokenPayload | AuthJwtPayload;
 
 export type TokenResponseWrap = {
-  __typename?: 'TokenResponseWrap';
   rejection: Maybe<Rejection>;
   token: Maybe<Scalars['String']>;
 };
 
 export type TokenResult = {
-  __typename?: 'TokenResult';
   isValid: Scalars['Boolean'];
   payload: Maybe<TokenPayloadUnion>;
 };
 
 export type Topic = {
-  __typename?: 'Topic';
   id: Scalars['Int'];
   isEnabled: Scalars['Boolean'];
   sortOrder: Scalars['Int'];
@@ -3329,19 +3255,16 @@ export type Topic = {
 
 
 export type Unit = {
-  __typename?: 'Unit';
   id: Scalars['Int'];
   name: Scalars['String'];
 };
 
 export type UnitResponseWrap = {
-  __typename?: 'UnitResponseWrap';
   rejection: Maybe<Rejection>;
   unit: Maybe<Unit>;
 };
 
 export type UpdateAnswerResponseWrap = {
-  __typename?: 'UpdateAnswerResponseWrap';
   questionId: Maybe<Scalars['String']>;
   rejection: Maybe<Rejection>;
 };
@@ -3414,7 +3337,6 @@ export type UpdateScheduledEventInput = {
 };
 
 export type User = {
-  __typename?: 'User';
   birthdate: Scalars['String'];
   created: Scalars['String'];
   department: Scalars['String'];
@@ -3464,13 +3386,11 @@ export type UserProposalsFilter = {
 };
 
 export type UserQueryResult = {
-  __typename?: 'UserQueryResult';
   totalCount: Scalars['Int'];
   users: Array<BasicUserDetails>;
 };
 
 export type UserResponseWrap = {
-  __typename?: 'UserResponseWrap';
   rejection: Maybe<Rejection>;
   user: Maybe<User>;
 };
@@ -3486,7 +3406,6 @@ export enum UserRole {
 }
 
 export type Visit = {
-  __typename?: 'Visit';
   creatorId: Scalars['Int'];
   id: Scalars['Int'];
   proposal: Proposal;
@@ -3501,14 +3420,12 @@ export type Visit = {
 };
 
 export type VisitBasisConfig = {
-  __typename?: 'VisitBasisConfig';
   required: Scalars['Boolean'];
   small_label: Scalars['String'];
   tooltip: Scalars['String'];
 };
 
 export type VisitRegistration = {
-  __typename?: 'VisitRegistration';
   isRegistrationSubmitted: Scalars['Boolean'];
   questionary: Questionary;
   registrationQuestionaryId: Maybe<Scalars['Int']>;
@@ -3519,13 +3436,11 @@ export type VisitRegistration = {
 };
 
 export type VisitRegistrationResponseWrap = {
-  __typename?: 'VisitRegistrationResponseWrap';
   registration: Maybe<VisitRegistration>;
   rejection: Maybe<Rejection>;
 };
 
 export type VisitResponseWrap = {
-  __typename?: 'VisitResponseWrap';
   rejection: Maybe<Rejection>;
   visit: Maybe<Visit>;
 };
@@ -3547,101 +3462,60 @@ export type AddEquipmentResponsibleMutationVariables = Exact<{
 }>;
 
 
-export type AddEquipmentResponsibleMutation = (
-  { __typename?: 'Mutation' }
-  & Pick<Mutation, 'addEquipmentResponsible'>
-);
+export type AddEquipmentResponsibleMutation = Pick<Mutation, 'addEquipmentResponsible'>;
 
 export type AssignEquipmentToScheduledEventMutationVariables = Exact<{
   assignEquipmentsToScheduledEventInput: AssignEquipmentsToScheduledEventInput;
 }>;
 
 
-export type AssignEquipmentToScheduledEventMutation = (
-  { __typename?: 'Mutation' }
-  & Pick<Mutation, 'assignToScheduledEvents'>
-);
+export type AssignEquipmentToScheduledEventMutation = Pick<Mutation, 'assignToScheduledEvents'>;
 
 export type ConfirmEquipmentAssignmentMutationVariables = Exact<{
   confirmEquipmentAssignmentInput: ConfirmEquipmentAssignmentInput;
 }>;
 
 
-export type ConfirmEquipmentAssignmentMutation = (
-  { __typename?: 'Mutation' }
-  & Pick<Mutation, 'confirmEquipmentAssignment'>
-);
+export type ConfirmEquipmentAssignmentMutation = Pick<Mutation, 'confirmEquipmentAssignment'>;
 
 export type CreateEquipmentMutationVariables = Exact<{
   newEquipmentInput: EquipmentInput;
 }>;
 
 
-export type CreateEquipmentMutation = (
-  { __typename?: 'Mutation' }
-  & { createEquipment: (
-    { __typename?: 'EquipmentResponseWrap' }
-    & Pick<EquipmentResponseWrap, 'error'>
-    & { equipment: Maybe<(
-      { __typename?: 'Equipment' }
-      & Pick<Equipment, 'id' | 'createdAt' | 'updatedAt' | 'name' | 'description' | 'maintenanceStartsAt' | 'maintenanceEndsAt' | 'autoAccept'>
-    )> }
-  ) }
-);
+export type CreateEquipmentMutation = { createEquipment: (
+    Pick<EquipmentResponseWrap, 'error'>
+    & { equipment: Maybe<Pick<Equipment, 'id' | 'createdAt' | 'updatedAt' | 'name' | 'description' | 'maintenanceStartsAt' | 'maintenanceEndsAt' | 'autoAccept'>> }
+  ) };
 
 export type DeleteEquipmentAssignmentMutationVariables = Exact<{
   deleteEquipmentAssignmentInput: DeleteEquipmentAssignmentInput;
 }>;
 
 
-export type DeleteEquipmentAssignmentMutation = (
-  { __typename?: 'Mutation' }
-  & Pick<Mutation, 'deleteEquipmentAssignment'>
-);
+export type DeleteEquipmentAssignmentMutation = Pick<Mutation, 'deleteEquipmentAssignment'>;
 
 export type GetAvailableEquipmentsQueryVariables = Exact<{
   scheduledEventId: Scalars['Int'];
 }>;
 
 
-export type GetAvailableEquipmentsQuery = (
-  { __typename?: 'Query' }
-  & { availableEquipments: Array<(
-    { __typename?: 'Equipment' }
-    & Pick<Equipment, 'id' | 'createdAt' | 'updatedAt' | 'name' | 'description' | 'maintenanceStartsAt' | 'maintenanceEndsAt' | 'autoAccept'>
-  )> }
-);
+export type GetAvailableEquipmentsQuery = { availableEquipments: Array<Pick<Equipment, 'id' | 'createdAt' | 'updatedAt' | 'name' | 'description' | 'maintenanceStartsAt' | 'maintenanceEndsAt' | 'autoAccept'>> };
 
 export type GetEquipmentQueryVariables = Exact<{
   id: Scalars['Int'];
 }>;
 
 
-export type GetEquipmentQuery = (
-  { __typename?: 'Query' }
-  & { equipment: Maybe<(
-    { __typename?: 'Equipment' }
-    & Pick<Equipment, 'id' | 'createdAt' | 'updatedAt' | 'name' | 'description' | 'maintenanceStartsAt' | 'maintenanceEndsAt' | 'autoAccept'>
-    & { owner: Maybe<(
-      { __typename?: 'User' }
-      & Pick<User, 'id' | 'firstname' | 'lastname'>
-    )>, equipmentResponsible: Array<(
-      { __typename?: 'User' }
-      & Pick<User, 'id' | 'firstname' | 'lastname'>
-    )> }
-  )> }
-);
+export type GetEquipmentQuery = { equipment: Maybe<(
+    Pick<Equipment, 'id' | 'createdAt' | 'updatedAt' | 'name' | 'description' | 'maintenanceStartsAt' | 'maintenanceEndsAt' | 'autoAccept'>
+    & { owner: Maybe<Pick<User, 'id' | 'firstname' | 'lastname'>>, equipmentResponsible: Array<Pick<User, 'id' | 'firstname' | 'lastname'>> }
+  )> };
 
 export type GetEquipmentsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetEquipmentsQuery = (
-  { __typename?: 'Query' }
-  & { equipments: Array<(
-    { __typename?: 'Equipment' }
-    & Pick<Equipment, 'id' | 'createdAt' | 'updatedAt' | 'name' | 'description' | 'maintenanceStartsAt' | 'maintenanceEndsAt' | 'autoAccept'>
-  )> }
-);
+export type GetEquipmentsQuery = { equipments: Array<Pick<Equipment, 'id' | 'createdAt' | 'updatedAt' | 'name' | 'description' | 'maintenanceStartsAt' | 'maintenanceEndsAt' | 'autoAccept'>> };
 
 export type UpdateEquipmentMutationVariables = Exact<{
   id: Scalars['Int'];
@@ -3649,76 +3523,45 @@ export type UpdateEquipmentMutationVariables = Exact<{
 }>;
 
 
-export type UpdateEquipmentMutation = (
-  { __typename?: 'Mutation' }
-  & { updateEquipment: (
-    { __typename?: 'EquipmentResponseWrap' }
-    & Pick<EquipmentResponseWrap, 'error'>
-    & { equipment: Maybe<(
-      { __typename?: 'Equipment' }
-      & Pick<Equipment, 'id' | 'name' | 'description' | 'maintenanceStartsAt' | 'maintenanceEndsAt' | 'autoAccept'>
-    )> }
-  ) }
-);
+export type UpdateEquipmentMutation = { updateEquipment: (
+    Pick<EquipmentResponseWrap, 'error'>
+    & { equipment: Maybe<Pick<Equipment, 'id' | 'name' | 'description' | 'maintenanceStartsAt' | 'maintenanceEndsAt' | 'autoAccept'>> }
+  ) };
 
 export type UpdateEquipmentOwnerMutationVariables = Exact<{
   updateEquipmentOwnerInput: UpdateEquipmentOwnerInput;
 }>;
 
 
-export type UpdateEquipmentOwnerMutation = (
-  { __typename?: 'Mutation' }
-  & Pick<Mutation, 'updateEquipmentOwner'>
-);
+export type UpdateEquipmentOwnerMutation = Pick<Mutation, 'updateEquipmentOwner'>;
 
 export type GetUserInstrumentsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetUserInstrumentsQuery = (
-  { __typename?: 'Query' }
-  & { userInstruments: Maybe<(
-    { __typename?: 'InstrumentsQueryResult' }
-    & Pick<InstrumentsQueryResult, 'totalCount'>
-    & { instruments: Array<(
-      { __typename?: 'Instrument' }
-      & Pick<Instrument, 'id' | 'name'>
-    )> }
-  )> }
-);
+export type GetUserInstrumentsQuery = { userInstruments: Maybe<(
+    Pick<InstrumentsQueryResult, 'totalCount'>
+    & { instruments: Array<Pick<Instrument, 'id' | 'name'>> }
+  )> };
 
 export type AddLostTimeMutationVariables = Exact<{
   input: AddLostTimeInput;
 }>;
 
 
-export type AddLostTimeMutation = (
-  { __typename?: 'Mutation' }
-  & { addLostTime: (
-    { __typename?: 'LostTimeResponseWrap' }
-    & Pick<LostTimeResponseWrap, 'error'>
-    & { lostTime: Maybe<(
-      { __typename?: 'LostTime' }
-      & Pick<LostTime, 'id' | 'startsAt' | 'endsAt' | 'scheduledEventId'>
-    )> }
-  ) }
-);
+export type AddLostTimeMutation = { addLostTime: (
+    Pick<LostTimeResponseWrap, 'error'>
+    & { lostTime: Maybe<Pick<LostTime, 'id' | 'startsAt' | 'endsAt' | 'scheduledEventId'>> }
+  ) };
 
 export type DeleteLostTimeMutationVariables = Exact<{
   input: DeleteLostTimeInput;
 }>;
 
 
-export type DeleteLostTimeMutation = (
-  { __typename?: 'Mutation' }
-  & { deleteLostTime: (
-    { __typename?: 'LostTimeResponseWrap' }
-    & Pick<LostTimeResponseWrap, 'error'>
-    & { lostTime: Maybe<(
-      { __typename?: 'LostTime' }
-      & Pick<LostTime, 'id' | 'startsAt' | 'endsAt' | 'scheduledEventId'>
-    )> }
-  ) }
-);
+export type DeleteLostTimeMutation = { deleteLostTime: (
+    Pick<LostTimeResponseWrap, 'error'>
+    & { lostTime: Maybe<Pick<LostTime, 'id' | 'startsAt' | 'endsAt' | 'scheduledEventId'>> }
+  ) };
 
 export type GetProposalBookingLostTimesQueryVariables = Exact<{
   proposalBookingId: Scalars['Int'];
@@ -3726,103 +3569,57 @@ export type GetProposalBookingLostTimesQueryVariables = Exact<{
 }>;
 
 
-export type GetProposalBookingLostTimesQuery = (
-  { __typename?: 'Query' }
-  & { proposalBookingLostTimes: Array<(
-    { __typename?: 'LostTime' }
-    & Pick<LostTime, 'id' | 'startsAt' | 'scheduledEventId' | 'endsAt'>
-  )> }
-);
+export type GetProposalBookingLostTimesQuery = { proposalBookingLostTimes: Array<Pick<LostTime, 'id' | 'startsAt' | 'scheduledEventId' | 'endsAt'>> };
 
 export type UpdateLostTimeMutationVariables = Exact<{
   input: UpdateLostTimeInput;
 }>;
 
 
-export type UpdateLostTimeMutation = (
-  { __typename?: 'Mutation' }
-  & { updateLostTime: (
-    { __typename?: 'LostTimeResponseWrap' }
-    & Pick<LostTimeResponseWrap, 'error'>
-    & { lostTime: Maybe<(
-      { __typename?: 'LostTime' }
-      & Pick<LostTime, 'id' | 'startsAt' | 'endsAt' | 'scheduledEventId'>
-    )> }
-  ) }
-);
+export type UpdateLostTimeMutation = { updateLostTime: (
+    Pick<LostTimeResponseWrap, 'error'>
+    & { lostTime: Maybe<Pick<LostTime, 'id' | 'startsAt' | 'endsAt' | 'scheduledEventId'>> }
+  ) };
 
 export type AddClientLogMutationVariables = Exact<{
   error: Scalars['String'];
 }>;
 
 
-export type AddClientLogMutation = (
-  { __typename?: 'Mutation' }
-  & { addClientLog: (
-    { __typename?: 'SuccessResponseWrap' }
-    & Pick<SuccessResponseWrap, 'isSuccess'>
-    & { rejection: Maybe<(
-      { __typename?: 'Rejection' }
-      & Pick<Rejection, 'reason'>
-    )> }
-  ) }
-);
+export type AddClientLogMutation = { addClientLog: (
+    Pick<SuccessResponseWrap, 'isSuccess'>
+    & { rejection: Maybe<Pick<Rejection, 'reason'>> }
+  ) };
 
 export type GetRefreshedTokenMutationVariables = Exact<{
   token: Scalars['String'];
 }>;
 
 
-export type GetRefreshedTokenMutation = (
-  { __typename?: 'Mutation' }
-  & { token: (
-    { __typename?: 'TokenResponseWrap' }
-    & Pick<TokenResponseWrap, 'token'>
-    & { rejection: Maybe<(
-      { __typename?: 'Rejection' }
-      & Pick<Rejection, 'reason'>
-    )> }
-  ) }
-);
+export type GetRefreshedTokenMutation = { token: (
+    Pick<TokenResponseWrap, 'token'>
+    & { rejection: Maybe<Pick<Rejection, 'reason'>> }
+  ) };
 
 export type GetSchedulerConfigQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetSchedulerConfigQuery = (
-  { __typename?: 'Query' }
-  & { schedulerConfig: (
-    { __typename?: 'SchedulerConfig' }
-    & Pick<SchedulerConfig, 'authRedirect'>
-  ) }
-);
+export type GetSchedulerConfigQuery = { schedulerConfig: Pick<SchedulerConfig, 'authRedirect'> };
 
 export type ServerHealthCheckQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type ServerHealthCheckQuery = (
-  { __typename?: 'Query' }
-  & { healthCheck: (
-    { __typename?: 'HealthStats' }
-    & Pick<HealthStats, 'message'>
-    & { dbStats: Array<(
-      { __typename?: 'DbStat' }
-      & Pick<DbStat, 'total' | 'state'>
-    )> }
-  ) }
-);
+export type ServerHealthCheckQuery = { healthCheck: (
+    Pick<HealthStats, 'message'>
+    & { dbStats: Array<Pick<DbStat, 'total' | 'state'>> }
+  ) };
 
 export type ActivateProposalBookingMutationVariables = Exact<{
   id: Scalars['Int'];
 }>;
 
 
-export type ActivateProposalBookingMutation = (
-  { __typename?: 'Mutation' }
-  & { activateProposalBooking: (
-    { __typename?: 'ProposalBookingResponseWrap' }
-    & Pick<ProposalBookingResponseWrap, 'error'>
-  ) }
-);
+export type ActivateProposalBookingMutation = { activateProposalBooking: Pick<ProposalBookingResponseWrap, 'error'> };
 
 export type FinalizeProposalBookingMutationVariables = Exact<{
   action: ProposalBookingFinalizeAction;
@@ -3830,13 +3627,7 @@ export type FinalizeProposalBookingMutationVariables = Exact<{
 }>;
 
 
-export type FinalizeProposalBookingMutation = (
-  { __typename?: 'Mutation' }
-  & { finalizeProposalBooking: (
-    { __typename?: 'ProposalBookingResponseWrap' }
-    & Pick<ProposalBookingResponseWrap, 'error'>
-  ) }
-);
+export type FinalizeProposalBookingMutation = { finalizeProposalBooking: Pick<ProposalBookingResponseWrap, 'error'> };
 
 export type GetInstrumentProposalBookingsQueryVariables = Exact<{
   instrumentIds: Array<Scalars['Int']> | Scalars['Int'];
@@ -3844,26 +3635,10 @@ export type GetInstrumentProposalBookingsQueryVariables = Exact<{
 }>;
 
 
-export type GetInstrumentProposalBookingsQuery = (
-  { __typename?: 'Query' }
-  & { instrumentProposalBookings: Array<(
-    { __typename?: 'ProposalBooking' }
-    & Pick<ProposalBooking, 'id' | 'createdAt' | 'updatedAt' | 'status' | 'allocatedTime'>
-    & { call: Maybe<(
-      { __typename?: 'Call' }
-      & Pick<Call, 'id' | 'shortCode' | 'startCycle' | 'endCycle' | 'cycleComment'>
-    )>, proposal: Maybe<(
-      { __typename?: 'Proposal' }
-      & Pick<Proposal, 'primaryKey' | 'title' | 'proposalId'>
-    )>, instrument: Maybe<(
-      { __typename?: 'Instrument' }
-      & Pick<Instrument, 'id' | 'name'>
-    )>, scheduledEvents: Array<(
-      { __typename?: 'ScheduledEvent' }
-      & Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt'>
-    )> }
-  )> }
-);
+export type GetInstrumentProposalBookingsQuery = { instrumentProposalBookings: Array<(
+    Pick<ProposalBooking, 'id' | 'createdAt' | 'updatedAt' | 'status' | 'allocatedTime'>
+    & { call: Maybe<Pick<Call, 'id' | 'shortCode' | 'startCycle' | 'endCycle' | 'cycleComment'>>, proposal: Maybe<Pick<Proposal, 'primaryKey' | 'title' | 'proposalId'>>, instrument: Maybe<Pick<Instrument, 'id' | 'name'>>, scheduledEvents: Array<Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt'>> }
+  )> };
 
 export type GetProposalBookingQueryVariables = Exact<{
   id: Scalars['Int'];
@@ -3871,121 +3646,63 @@ export type GetProposalBookingQueryVariables = Exact<{
 }>;
 
 
-export type GetProposalBookingQuery = (
-  { __typename?: 'Query' }
-  & { proposalBooking: Maybe<(
-    { __typename?: 'ProposalBooking' }
-    & Pick<ProposalBooking, 'id' | 'createdAt' | 'updatedAt' | 'status' | 'allocatedTime'>
-    & { call: Maybe<(
-      { __typename?: 'Call' }
-      & Pick<Call, 'id' | 'shortCode' | 'startCycle' | 'endCycle' | 'cycleComment'>
-    )>, proposal: Maybe<(
-      { __typename?: 'Proposal' }
-      & Pick<Proposal, 'primaryKey' | 'title' | 'proposalId'>
-    )>, scheduledEvents: Array<(
-      { __typename?: 'ScheduledEvent' }
-      & Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt' | 'bookingType' | 'status' | 'description'>
-      & { scheduledBy: Maybe<(
-        { __typename?: 'User' }
-        & Pick<User, 'id' | 'firstname' | 'lastname'>
-      )>, localContact: Maybe<(
-        { __typename?: 'User' }
-        & Pick<User, 'id' | 'firstname' | 'lastname'>
-      )> }
+export type GetProposalBookingQuery = { proposalBooking: Maybe<(
+    Pick<ProposalBooking, 'id' | 'createdAt' | 'updatedAt' | 'status' | 'allocatedTime'>
+    & { call: Maybe<Pick<Call, 'id' | 'shortCode' | 'startCycle' | 'endCycle' | 'cycleComment'>>, proposal: Maybe<Pick<Proposal, 'primaryKey' | 'title' | 'proposalId'>>, scheduledEvents: Array<(
+      Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt' | 'bookingType' | 'status' | 'description'>
+      & { scheduledBy: Maybe<Pick<User, 'id' | 'firstname' | 'lastname'>>, localContact: Maybe<Pick<BasicUserDetails, 'id' | 'firstname' | 'lastname'>> }
     )>, instrument: Maybe<(
-      { __typename?: 'Instrument' }
-      & Pick<Instrument, 'id' | 'name'>
-      & { beamlineManager: (
-        { __typename?: 'BasicUserDetails' }
-        & Pick<BasicUserDetails, 'id' | 'firstname' | 'lastname' | 'organisation'>
-      ), scientists: Array<(
-        { __typename?: 'BasicUserDetails' }
-        & Pick<BasicUserDetails, 'id' | 'firstname' | 'lastname' | 'organisation'>
-      )> }
+      Pick<Instrument, 'id' | 'name'>
+      & { beamlineManager: Pick<BasicUserDetails, 'id' | 'firstname' | 'lastname' | 'organisation'>, scientists: Array<Pick<BasicUserDetails, 'id' | 'firstname' | 'lastname' | 'organisation'>> }
     )> }
-  )> }
-);
+  )> };
 
 export type ReopenProposalBookingMutationVariables = Exact<{
   id: Scalars['Int'];
 }>;
 
 
-export type ReopenProposalBookingMutation = (
-  { __typename?: 'Mutation' }
-  & { reopenProposalBooking: (
-    { __typename?: 'ProposalBookingResponseWrap' }
-    & Pick<ProposalBookingResponseWrap, 'error'>
-  ) }
-);
+export type ReopenProposalBookingMutation = { reopenProposalBooking: Pick<ProposalBookingResponseWrap, 'error'> };
 
 export type ActivateScheduledEventMutationVariables = Exact<{
   input: ActivateScheduledEventInput;
 }>;
 
 
-export type ActivateScheduledEventMutation = (
-  { __typename?: 'Mutation' }
-  & { activateScheduledEvent: (
-    { __typename?: 'ScheduledEventResponseWrap' }
-    & Pick<ScheduledEventResponseWrap, 'error'>
-    & { scheduledEvent: Maybe<(
-      { __typename?: 'ScheduledEvent' }
-      & Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt'>
-    )> }
-  ) }
-);
+export type ActivateScheduledEventMutation = { activateScheduledEvent: (
+    Pick<ScheduledEventResponseWrap, 'error'>
+    & { scheduledEvent: Maybe<Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt'>> }
+  ) };
 
 export type CreateScheduledEventMutationVariables = Exact<{
   input: NewScheduledEventInput;
 }>;
 
 
-export type CreateScheduledEventMutation = (
-  { __typename?: 'Mutation' }
-  & { createScheduledEvent: (
-    { __typename?: 'ScheduledEventResponseWrap' }
-    & Pick<ScheduledEventResponseWrap, 'error'>
+export type CreateScheduledEventMutation = { createScheduledEvent: (
+    Pick<ScheduledEventResponseWrap, 'error'>
     & { scheduledEvent: Maybe<(
-      { __typename?: 'ScheduledEvent' }
-      & Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt' | 'bookingType' | 'status' | 'description'>
-      & { scheduledBy: Maybe<(
-        { __typename?: 'User' }
-        & Pick<User, 'id' | 'firstname' | 'lastname'>
-      )> }
+      Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt' | 'bookingType' | 'status' | 'description'>
+      & { scheduledBy: Maybe<Pick<User, 'id' | 'firstname' | 'lastname'>> }
     )> }
-  ) }
-);
+  ) };
 
 export type DeleteScheduledEventsMutationVariables = Exact<{
   input: DeleteScheduledEventsInput;
 }>;
 
 
-export type DeleteScheduledEventsMutation = (
-  { __typename?: 'Mutation' }
-  & { deleteScheduledEvents: (
-    { __typename?: 'ScheduledEventsResponseWrap' }
-    & Pick<ScheduledEventsResponseWrap, 'error'>
-    & { scheduledEvents: Maybe<Array<(
-      { __typename?: 'ScheduledEvent' }
-      & Pick<ScheduledEvent, 'id' | 'bookingType' | 'startsAt' | 'endsAt' | 'description' | 'status'>
-    )>> }
-  ) }
-);
+export type DeleteScheduledEventsMutation = { deleteScheduledEvents: (
+    Pick<ScheduledEventsResponseWrap, 'error'>
+    & { scheduledEvents: Maybe<Array<Pick<ScheduledEvent, 'id' | 'bookingType' | 'startsAt' | 'endsAt' | 'description' | 'status'>>> }
+  ) };
 
 export type FinalizeScheduledEventMutationVariables = Exact<{
   input: FinalizeScheduledEventInput;
 }>;
 
 
-export type FinalizeScheduledEventMutation = (
-  { __typename?: 'Mutation' }
-  & { finalizeScheduledEvent: (
-    { __typename?: 'ScheduledEventResponseWrap' }
-    & Pick<ScheduledEventResponseWrap, 'error'>
-  ) }
-);
+export type FinalizeScheduledEventMutation = { finalizeScheduledEvent: Pick<ScheduledEventResponseWrap, 'error'> };
 
 export type GetEquipmentScheduledEventsQueryVariables = Exact<{
   equipmentIds: Array<Scalars['Int']> | Scalars['Int'];
@@ -3994,58 +3711,29 @@ export type GetEquipmentScheduledEventsQueryVariables = Exact<{
 }>;
 
 
-export type GetEquipmentScheduledEventsQuery = (
-  { __typename?: 'Query' }
-  & { equipments: Array<(
-    { __typename?: 'Equipment' }
-    & Pick<Equipment, 'id' | 'name'>
+export type GetEquipmentScheduledEventsQuery = { equipments: Array<(
+    Pick<Equipment, 'id' | 'name'>
     & { events: Array<(
-      { __typename?: 'ScheduledEvent' }
-      & Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt' | 'status' | 'equipmentAssignmentStatus' | 'equipmentId'>
+      Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt' | 'status' | 'equipmentAssignmentStatus' | 'equipmentId'>
       & { proposalBooking: Maybe<(
-        { __typename?: 'ProposalBooking' }
-        & Pick<ProposalBooking, 'status'>
+        Pick<ProposalBooking, 'status'>
         & { proposal: Maybe<(
-          { __typename?: 'Proposal' }
-          & Pick<Proposal, 'primaryKey' | 'title' | 'proposalId'>
-          & { proposer: Maybe<(
-            { __typename?: 'BasicUserDetails' }
-            & Pick<BasicUserDetails, 'firstname' | 'lastname'>
-          )> }
+          Pick<Proposal, 'primaryKey' | 'title' | 'proposalId'>
+          & { proposer: Maybe<Pick<BasicUserDetails, 'firstname' | 'lastname'>> }
         )> }
-      )>, instrument: Maybe<(
-        { __typename?: 'Instrument' }
-        & Pick<Instrument, 'id' | 'name'>
-      )>, scheduledBy: Maybe<(
-        { __typename?: 'User' }
-        & Pick<User, 'id' | 'firstname' | 'lastname'>
-      )>, localContact: Maybe<(
-        { __typename?: 'User' }
-        & Pick<User, 'id' | 'firstname' | 'lastname'>
-      )> }
+      )>, instrument: Maybe<Pick<Instrument, 'id' | 'name'>>, scheduledBy: Maybe<Pick<User, 'id' | 'firstname' | 'lastname'>>, localContact: Maybe<Pick<BasicUserDetails, 'id' | 'firstname' | 'lastname'>> }
     )> }
-  )> }
-);
+  )> };
 
 export type GetProposalBookingScheduledEventsQueryVariables = Exact<{
   proposalBookingId: Scalars['Int'];
 }>;
 
 
-export type GetProposalBookingScheduledEventsQuery = (
-  { __typename?: 'Query' }
-  & { proposalBookingScheduledEvents: Array<(
-    { __typename?: 'ScheduledEvent' }
-    & Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt' | 'bookingType' | 'status' | 'description'>
-    & { scheduledBy: Maybe<(
-      { __typename?: 'User' }
-      & Pick<User, 'id' | 'firstname' | 'lastname'>
-    )>, localContact: Maybe<(
-      { __typename?: 'User' }
-      & Pick<User, 'id' | 'firstname' | 'lastname'>
-    )> }
-  )> }
-);
+export type GetProposalBookingScheduledEventsQuery = { proposalBookingScheduledEvents: Array<(
+    Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt' | 'bookingType' | 'status' | 'description'>
+    & { scheduledBy: Maybe<Pick<User, 'id' | 'firstname' | 'lastname'>>, localContact: Maybe<Pick<BasicUserDetails, 'id' | 'firstname' | 'lastname'>> }
+  )> };
 
 export type GetScheduledEventEquipmentsQueryVariables = Exact<{
   proposalBookingId: Scalars['Int'];
@@ -4053,16 +3741,7 @@ export type GetScheduledEventEquipmentsQueryVariables = Exact<{
 }>;
 
 
-export type GetScheduledEventEquipmentsQuery = (
-  { __typename?: 'Query' }
-  & { proposalBookingScheduledEvent: Maybe<(
-    { __typename?: 'ScheduledEvent' }
-    & { equipments: Array<(
-      { __typename?: 'EquipmentWithAssignmentStatus' }
-      & Pick<EquipmentWithAssignmentStatus, 'id' | 'name' | 'description' | 'maintenanceStartsAt' | 'maintenanceEndsAt' | 'status'>
-    )> }
-  )> }
-);
+export type GetScheduledEventEquipmentsQuery = { proposalBookingScheduledEvent: Maybe<{ equipments: Array<Pick<EquipmentWithAssignmentStatus, 'id' | 'name' | 'description' | 'maintenanceStartsAt' | 'maintenanceEndsAt' | 'status'>> }> };
 
 export type GetScheduledEventWithEquipmentsQueryVariables = Exact<{
   proposalBookingId: Scalars['Int'];
@@ -4071,37 +3750,16 @@ export type GetScheduledEventWithEquipmentsQueryVariables = Exact<{
 }>;
 
 
-export type GetScheduledEventWithEquipmentsQuery = (
-  { __typename?: 'Query' }
-  & { proposalBookingScheduledEvent: Maybe<(
-    { __typename?: 'ScheduledEvent' }
-    & Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt' | 'status'>
+export type GetScheduledEventWithEquipmentsQuery = { proposalBookingScheduledEvent: Maybe<(
+    Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt' | 'status'>
     & { proposalBooking: Maybe<(
-      { __typename?: 'ProposalBooking' }
-      & Pick<ProposalBooking, 'id' | 'status' | 'allocatedTime'>
-      & { scheduledEvents: Array<(
-        { __typename?: 'ScheduledEvent' }
-        & Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt'>
-      )>, proposal: Maybe<(
-        { __typename?: 'Proposal' }
-        & Pick<Proposal, 'primaryKey' | 'title' | 'proposalId'>
-        & { proposer: Maybe<(
-          { __typename?: 'BasicUserDetails' }
-          & Pick<BasicUserDetails, 'firstname' | 'lastname'>
-        )> }
-      )>, call: Maybe<(
-        { __typename?: 'Call' }
-        & Pick<Call, 'id' | 'shortCode' | 'startCycle' | 'endCycle' | 'cycleComment'>
-      )> }
-    )>, scheduledBy: Maybe<(
-      { __typename?: 'User' }
-      & Pick<User, 'firstname' | 'lastname'>
-    )>, equipments: Array<(
-      { __typename?: 'EquipmentWithAssignmentStatus' }
-      & Pick<EquipmentWithAssignmentStatus, 'id' | 'name' | 'maintenanceStartsAt' | 'maintenanceEndsAt' | 'status'>
-    )> }
-  )> }
-);
+      Pick<ProposalBooking, 'id' | 'status' | 'allocatedTime'>
+      & { scheduledEvents: Array<Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt'>>, proposal: Maybe<(
+        Pick<Proposal, 'primaryKey' | 'title' | 'proposalId'>
+        & { proposer: Maybe<Pick<BasicUserDetails, 'firstname' | 'lastname'>> }
+      )>, call: Maybe<Pick<Call, 'id' | 'shortCode' | 'startCycle' | 'endCycle' | 'cycleComment'>> }
+    )>, scheduledBy: Maybe<Pick<User, 'firstname' | 'lastname'>>, equipments: Array<Pick<EquipmentWithAssignmentStatus, 'id' | 'name' | 'maintenanceStartsAt' | 'maintenanceEndsAt' | 'status'>> }
+  )> };
 
 export type GetScheduledEventsQueryVariables = Exact<{
   filter: ScheduledEventFilter;
@@ -4109,96 +3767,48 @@ export type GetScheduledEventsQueryVariables = Exact<{
 }>;
 
 
-export type GetScheduledEventsQuery = (
-  { __typename?: 'Query' }
-  & { scheduledEvents: Array<(
-    { __typename?: 'ScheduledEvent' }
-    & Pick<ScheduledEvent, 'id' | 'bookingType' | 'equipmentId' | 'startsAt' | 'endsAt' | 'status' | 'description'>
-    & { instrument: Maybe<(
-      { __typename?: 'Instrument' }
-      & Pick<Instrument, 'id' | 'name'>
-    )>, scheduledBy: Maybe<(
-      { __typename?: 'User' }
-      & Pick<User, 'firstname' | 'lastname'>
-    )>, localContact: Maybe<(
-      { __typename?: 'User' }
-      & Pick<User, 'firstname' | 'lastname'>
-    )>, proposalBooking: Maybe<(
-      { __typename?: 'ProposalBooking' }
-      & Pick<ProposalBooking, 'id' | 'createdAt' | 'updatedAt' | 'status' | 'allocatedTime'>
+export type GetScheduledEventsQuery = { scheduledEvents: Array<(
+    Pick<ScheduledEvent, 'id' | 'bookingType' | 'equipmentId' | 'startsAt' | 'endsAt' | 'status' | 'description'>
+    & { instrument: Maybe<Pick<Instrument, 'id' | 'name'>>, scheduledBy: Maybe<Pick<User, 'firstname' | 'lastname'>>, localContact: Maybe<Pick<BasicUserDetails, 'firstname' | 'lastname'>>, proposalBooking: Maybe<(
+      Pick<ProposalBooking, 'id' | 'createdAt' | 'updatedAt' | 'status' | 'allocatedTime'>
       & { proposal: Maybe<(
-        { __typename?: 'Proposal' }
-        & Pick<Proposal, 'primaryKey' | 'title' | 'proposalId'>
-        & { proposer: Maybe<(
-          { __typename?: 'BasicUserDetails' }
-          & Pick<BasicUserDetails, 'firstname' | 'lastname'>
-        )> }
-      )>, call: Maybe<(
-        { __typename?: 'Call' }
-        & Pick<Call, 'id' | 'shortCode' | 'startCycle' | 'endCycle' | 'cycleComment'>
-      )>, scheduledEvents: Array<(
-        { __typename?: 'ScheduledEvent' }
-        & Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt'>
-      )> }
+        Pick<Proposal, 'primaryKey' | 'title' | 'proposalId'>
+        & { proposer: Maybe<Pick<BasicUserDetails, 'firstname' | 'lastname'>> }
+      )>, call: Maybe<Pick<Call, 'id' | 'shortCode' | 'startCycle' | 'endCycle' | 'cycleComment'>>, scheduledEvents: Array<Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt'>> }
     )> }
-  )> }
-);
+  )> };
 
 export type GetScheduledEventsWithEquipmentsQueryVariables = Exact<{
   proposalBookingId: Scalars['Int'];
 }>;
 
 
-export type GetScheduledEventsWithEquipmentsQuery = (
-  { __typename?: 'Query' }
-  & { proposalBookingScheduledEvents: Array<(
-    { __typename?: 'ScheduledEvent' }
-    & Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt' | 'status'>
-    & { equipments: Array<(
-      { __typename?: 'EquipmentWithAssignmentStatus' }
-      & Pick<EquipmentWithAssignmentStatus, 'id' | 'name' | 'description' | 'maintenanceStartsAt' | 'maintenanceEndsAt' | 'status'>
-    )> }
-  )> }
-);
+export type GetScheduledEventsWithEquipmentsQuery = { proposalBookingScheduledEvents: Array<(
+    Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt' | 'status'>
+    & { equipments: Array<Pick<EquipmentWithAssignmentStatus, 'id' | 'name' | 'description' | 'maintenanceStartsAt' | 'maintenanceEndsAt' | 'status'>> }
+  )> };
 
 export type ReopenScheduledEventMutationVariables = Exact<{
   id: Scalars['Int'];
 }>;
 
 
-export type ReopenScheduledEventMutation = (
-  { __typename?: 'Mutation' }
-  & { reopenScheduledEvent: (
-    { __typename?: 'ScheduledEventResponseWrap' }
-    & Pick<ScheduledEventResponseWrap, 'error'>
-  ) }
-);
+export type ReopenScheduledEventMutation = { reopenScheduledEvent: Pick<ScheduledEventResponseWrap, 'error'> };
 
 export type UpdateScheduledEventMutationVariables = Exact<{
   input: UpdateScheduledEventInput;
 }>;
 
 
-export type UpdateScheduledEventMutation = (
-  { __typename?: 'Mutation' }
-  & { updateScheduledEvent: (
-    { __typename?: 'ScheduledEventResponseWrap' }
-    & Pick<ScheduledEventResponseWrap, 'error'>
+export type UpdateScheduledEventMutation = { updateScheduledEvent: (
+    Pick<ScheduledEventResponseWrap, 'error'>
     & { scheduledEvent: Maybe<(
-      { __typename?: 'ScheduledEvent' }
-      & Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt'>
-      & { localContact: Maybe<(
-        { __typename?: 'User' }
-        & Pick<User, 'firstname' | 'lastname'>
-      )> }
+      Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt'>
+      & { localContact: Maybe<Pick<BasicUserDetails, 'firstname' | 'lastname'>> }
     )> }
-  ) }
-);
+  ) };
 
-export type BasicUserDetailsFragment = (
-  { __typename?: 'BasicUserDetails' }
-  & Pick<BasicUserDetails, 'id' | 'firstname' | 'lastname' | 'organisation' | 'position' | 'created' | 'placeholder'>
-);
+export type BasicUserDetailsFragment = Pick<BasicUserDetails, 'id' | 'firstname' | 'lastname' | 'organisation' | 'position' | 'created' | 'placeholder'>;
 
 export type GetUsersQueryVariables = Exact<{
   filter?: Maybe<Scalars['String']>;
@@ -4209,17 +3819,10 @@ export type GetUsersQueryVariables = Exact<{
 }>;
 
 
-export type GetUsersQuery = (
-  { __typename?: 'Query' }
-  & { users: Maybe<(
-    { __typename?: 'UserQueryResult' }
-    & Pick<UserQueryResult, 'totalCount'>
-    & { users: Array<(
-      { __typename?: 'BasicUserDetails' }
-      & BasicUserDetailsFragment
-    )> }
-  )> }
-);
+export type GetUsersQuery = { users: Maybe<(
+    Pick<UserQueryResult, 'totalCount'>
+    & { users: Array<BasicUserDetailsFragment> }
+  )> };
 
 export const BasicUserDetailsFragmentDoc = gql`
     fragment basicUserDetails on BasicUserDetails {

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -2098,6 +2098,7 @@ export type ProposalTemplate = {
   group: TemplateGroup;
   groupId: TemplateGroupId;
   isArchived: Scalars['Boolean'];
+  json: Scalars['String'];
   name: Scalars['String'];
   questionaryCount: Scalars['Int'];
   steps: Array<TemplateStep>;
@@ -3230,6 +3231,7 @@ export type Template = {
   group: TemplateGroup;
   groupId: TemplateGroupId;
   isArchived: Scalars['Boolean'];
+  json: Scalars['String'];
   name: Scalars['String'];
   questionaryCount: Scalars['Int'];
   steps: Array<TemplateStep>;

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -3027,6 +3027,8 @@ export type ScheduledEventCore = {
   esi: Maybe<ExperimentSafetyInput>;
   feedback: Maybe<Feedback>;
   id: Scalars['Int'];
+  localContact: Maybe<BasicUserDetails>;
+  localContactId: Maybe<Scalars['Int']>;
   startsAt: Scalars['TzLessDateTime'];
   status: ProposalBookingStatusCore;
   visit: Maybe<Visit>;

--- a/src/graphql/proposalBooking/getProposalBooking.graphql
+++ b/src/graphql/proposalBooking/getProposalBooking.graphql
@@ -26,12 +26,29 @@ query getProposalBooking(
         firstname
         lastname
       }
+      localContact {
+        id
+        firstname
+        lastname
+      }
       status
       description
     }
     instrument {
       id
       name
+      beamlineManager {
+        id
+        firstname
+        lastname
+        organisation
+      }
+      scientists {
+        id
+        firstname
+        lastname
+        organisation
+      }
     }
     createdAt
     updatedAt

--- a/src/graphql/scheduledEvent/getEquipmentScheduledEvents.graphql
+++ b/src/graphql/scheduledEvent/getEquipmentScheduledEvents.graphql
@@ -34,6 +34,11 @@ query getEquipmentScheduledEvents(
         firstname
         lastname
       }
+      localContact {
+        id
+        firstname
+        lastname
+      }
     }
   }
 }

--- a/src/graphql/scheduledEvent/getProposalBookingScheduledEvents.graphql
+++ b/src/graphql/scheduledEvent/getProposalBookingScheduledEvents.graphql
@@ -9,6 +9,11 @@ query getProposalBookingScheduledEvents($proposalBookingId: Int!) {
       firstname
       lastname
     }
+    localContact {
+      id
+      firstname
+      lastname
+    }
     status
     description
   }

--- a/src/graphql/scheduledEvent/getScheduledEvents.graphql
+++ b/src/graphql/scheduledEvent/getScheduledEvents.graphql
@@ -18,6 +18,10 @@ query getScheduledEvents(
       firstname
       lastname
     }
+    localContact {
+      firstname
+      lastname
+    }
     proposalBooking {
       id
       createdAt

--- a/src/graphql/scheduledEvent/updateScheduledEvent.graphql
+++ b/src/graphql/scheduledEvent/updateScheduledEvent.graphql
@@ -5,6 +5,10 @@ mutation updateScheduledEvent($input: UpdateScheduledEventInput!) {
       id
       startsAt
       endsAt
+      localContact {
+        firstname
+        lastname
+      }
     }
   }
 }

--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -1,0 +1,5 @@
+import { User } from 'generated/sdk';
+
+export const getFullUserName = (
+  user?: Pick<User, 'firstname' | 'lastname'> | null
+): string => (user ? `${user.firstname} ${user.lastname}` : 'None');


### PR DESCRIPTION
## Description

Added the ability to assign local contact, from list of instrument scientist on that instrument, to experiment booking.

## Motivation and Context

Every experiment time should have ability to assign local contact from the instrument scientists assigned on the instrument that experiment is booked to.

## How Has This Been Tested

- e2e tests
- manual tests

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

https://user-images.githubusercontent.com/6333063/145542117-8bc160d2-3e19-4d3a-9377-33f0a4b30a31.mp4

## Depends on

- https://github.com/UserOfficeProject/user-office-scheduler-backend/pull/106
- https://github.com/UserOfficeProject/user-office-backend/pull/510

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
