### PR TITLE
Swap 2016 add local contact toolbar selection

### DIFF
--- a/cypress/integration/proposal-booking.spec.ts
+++ b/cypress/integration/proposal-booking.spec.ts
@@ -332,6 +332,64 @@ context('Proposal booking tests ', () => {
               .should('not.contain.text', 'None')
               .invoke('text')
               .should('not.equal', selectedLocalContactText);
+
+            cy.get('[data-cy="btn-save"]').click();
+
+            cy.get('#notistack-snackbar').contains('Scheduled event updated');
+          });
+      });
+
+      it('should be able to select and see local contact events in all views view', () => {
+        cy.get('[data-cy="btn-close-dialog"]').click();
+        cy.finishedLoading();
+
+        cy.get('[data-cy="input-instrument-select"] input').focus();
+        cy.get('[data-cy="input-instrument-select"]')
+          .find('button[title="Clear"]')
+          .click();
+
+        cy.finishedLoading();
+
+        cy.get('[data-cy="input-local-contact-select"]').click();
+        cy.get(
+          '[aria-labelledby=input-local-contact-select-label] [role=option]'
+        )
+          .last()
+          .click();
+
+        cy.finishedLoading();
+
+        cy.get('.rbc-time-content .rbc-event')
+          .last()
+          .contains('999999')
+          .click();
+
+        cy.finishedLoading();
+
+        cy.contains(
+          `${getHourDateTimeAfter(2, 'days')} - ${getHourDateTimeAfter(
+            3,
+            'days'
+          )}`
+        );
+
+        cy.get('[data-cy="local-contact-details"] p')
+          .should('not.contain.text', 'None')
+          .invoke('text')
+          .then((newSelectedLocalContactText) => {
+            cy.get('[data-cy="btn-close-dialog"]').click();
+            cy.finishedLoading();
+
+            cy.get('[data-cy="scheduler-active-view"]').click();
+            cy.get('[data-value="Timeline"]').click();
+
+            cy.get('.react-calendar-timeline .rct-outer')
+              .should('contain.text', 'local contacts')
+              .and('contain.text', newSelectedLocalContactText);
+            cy.get('.react-calendar-timeline .rct-outer .rct-scroll').should(
+              'contain',
+              cy.contains(getHourDateTimeAfter(2, 'days'))
+            );
           });
       });
 

--- a/cypress/integration/proposal-booking.spec.ts
+++ b/cypress/integration/proposal-booking.spec.ts
@@ -376,7 +376,7 @@ context('Proposal booking tests ', () => {
         cy.get('[data-cy="local-contact-details"] p')
           .should('not.contain.text', 'None')
           .invoke('text')
-          .then((newSelectedLocalContactText) => {
+          .then((selectedLocalContactText) => {
             cy.get('[data-cy="btn-close-dialog"]').click();
             cy.finishedLoading();
 
@@ -385,11 +385,9 @@ context('Proposal booking tests ', () => {
 
             cy.get('.react-calendar-timeline .rct-outer')
               .should('contain.text', 'local contacts')
-              .and('contain.text', newSelectedLocalContactText);
-            cy.get('.react-calendar-timeline .rct-outer .rct-scroll').should(
-              'contain',
-              cy.contains(getHourDateTimeAfter(2, 'days'))
-            );
+              .and('contain.text', selectedLocalContactText);
+
+            cy.contains(getHourDateTimeAfter(2, 'days'));
           });
       });
 

--- a/cypress/integration/scheduled-events-timeline.spec.ts
+++ b/cypress/integration/scheduled-events-timeline.spec.ts
@@ -280,7 +280,7 @@ context('Scheduled events timeline tests', () => {
       );
 
       cy.get('[data-cy="btn-close-dialog"]').click();
-      
+
       cy.wait(500);
 
       cy.contains(defaultEventBookingHourDateTime).first().parent().click();
@@ -360,7 +360,7 @@ context('Scheduled events timeline tests', () => {
         .click();
 
       cy.get(
-        '[data-cy="calendar-timeline-view"] .react-calendar-timeline .rct-sidebar .rct-sidebar-row'
+        '[data-cy="calendar-timeline-view"] [data-cy="item-group"]'
       ).should('have.length', '3');
 
       cy.reload();
@@ -368,7 +368,7 @@ context('Scheduled events timeline tests', () => {
       cy.finishedLoading();
 
       cy.get(
-        '[data-cy="calendar-timeline-view"] .react-calendar-timeline .rct-sidebar .rct-sidebar-row'
+        '[data-cy="calendar-timeline-view"] [data-cy="item-group"]'
       ).should('have.length', '3');
 
       cy.get(

--- a/src/components/MenuItems.tsx
+++ b/src/components/MenuItems.tsx
@@ -10,8 +10,7 @@ import { NavLink, useLocation } from 'react-router-dom';
 import { useQuery } from 'hooks/common/useQuery';
 
 import {
-  getEquipmentIdsFromQuery,
-  getInstrumentIdsFromQuery,
+  getArrayOfIdsFromQuery,
   SchedulerViewPeriod,
 } from './calendar/CalendarViewContainer';
 import { PATH_CALENDAR, PATH_EQUIPMENTS, PATH_REQUESTS } from './paths';
@@ -26,6 +25,14 @@ const generateCalendarPath = (calendarState: CalendarLocalStorageState) => {
   if (calendarState.instrumentIds?.length) {
     path.push(
       `instrument=${encodeURIComponent(calendarState.instrumentIds.join(','))}`
+    );
+  }
+
+  if (calendarState.localContactIds?.length) {
+    path.push(
+      `localContact=${encodeURIComponent(
+        calendarState.localContactIds.join(',')
+      )}`
     );
   }
 
@@ -55,6 +62,7 @@ const getCalendarLocalStorageState = (): CalendarLocalStorageState | null => {
 type CalendarLocalStorageState = {
   instrumentIds: number[] | null;
   equipmentIds: number[] | null;
+  localContactIds: number[] | null;
   schedulerView: string | null;
   activeView: string | null;
   startsAt: string | null;
@@ -68,6 +76,7 @@ export default function MenuItems() {
 
   const queryInstrument = query.get('instrument');
   const queryEquipment = query.get('equipment');
+  const queryLocalContact = query.get('localContact');
   const querySchedulerView = query.get('schedulerView');
   const queryView = query.get('viewPeriod') as SchedulerViewPeriod;
   const queryStartsAt = query.get('startsAt');
@@ -80,6 +89,7 @@ export default function MenuItems() {
     const calendarInitialState: CalendarLocalStorageState = {
       instrumentIds: null,
       equipmentIds: null,
+      localContactIds: null,
       schedulerView: null,
       activeView: null,
       startsAt: null,
@@ -89,8 +99,9 @@ export default function MenuItems() {
       getCalendarLocalStorageState() || calendarInitialState;
 
     const calendarNewState = {
-      instrumentIds: getInstrumentIdsFromQuery(queryInstrument),
-      equipmentIds: getEquipmentIdsFromQuery(queryEquipment),
+      instrumentIds: getArrayOfIdsFromQuery(queryInstrument),
+      equipmentIds: getArrayOfIdsFromQuery(queryEquipment),
+      localContactIds: getArrayOfIdsFromQuery(queryLocalContact),
       schedulerView: querySchedulerView,
       activeView: queryView || calendarlocalStorageState.activeView,
       startsAt: queryStartsAt || calendarlocalStorageState.startsAt,
@@ -104,6 +115,7 @@ export default function MenuItems() {
     queryStartsAt,
     queryInstrument,
     queryEquipment,
+    queryLocalContact,
     location.pathname,
   ]);
 

--- a/src/components/calendar/CalendarViewContainer.tsx
+++ b/src/components/calendar/CalendarViewContainer.tsx
@@ -181,20 +181,11 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export const getInstrumentIdsFromQuery = (queryInstrument: string | null) => {
-  const queryInstrumentArray = queryInstrument?.split(',');
-  const queryInstrumentIds = queryInstrumentArray?.map((item) =>
-    parseInt(item)
-  );
+export const getArrayOfIdsFromQuery = (query: string | null) => {
+  const queryArray = query?.split(',');
+  const queryIds = queryArray?.map((item) => parseInt(item));
 
-  return queryInstrumentIds || [];
-};
-
-export const getEquipmentIdsFromQuery = (queryEquipment: string | null) => {
-  const queryEquipmentArray = queryEquipment?.split(',');
-  const queryEquipmentIds = queryEquipmentArray?.map((item) => parseInt(item));
-
-  return queryEquipmentIds || [];
+  return queryIds || [];
 };
 
 export default function CalendarViewContainer() {
@@ -239,8 +230,8 @@ export default function CalendarViewContainer() {
   const [startsAt, setStartsAt] = useState(moment().startOf(view).toDate());
   const [filter, setFilter] = useState(
     generateScheduledEventFilter(
-      getInstrumentIdsFromQuery(queryInstrument),
-      getEquipmentIdsFromQuery(queryLocalContact),
+      getArrayOfIdsFromQuery(queryInstrument),
+      getArrayOfIdsFromQuery(queryLocalContact),
       startsAt,
       view
     )
@@ -278,7 +269,7 @@ export default function CalendarViewContainer() {
       schedulerActiveView === SchedulerViews.CALENDAR ||
       schedulerActiveView === SchedulerViews.TABLE
     ) {
-      const queryInstrumentIds = getInstrumentIdsFromQuery(queryInstrument);
+      const queryInstrumentIds = getArrayOfIdsFromQuery(queryInstrument);
       // NOTE: If table or calendar view set the selected instrument to first one if multiple are selected in timeline view.
       if (queryInstrumentIds && queryInstrumentIds.length > 1) {
         query.set('instrument', `${queryInstrumentIds[0]}`);
@@ -291,7 +282,7 @@ export default function CalendarViewContainer() {
     proposalBookings,
     loading: loadingBookings,
     refresh: refreshBookings,
-  } = useInstrumentProposalBookings(getInstrumentIdsFromQuery(queryInstrument));
+  } = useInstrumentProposalBookings(getArrayOfIdsFromQuery(queryInstrument));
 
   const {
     scheduledEvents,
@@ -302,7 +293,7 @@ export default function CalendarViewContainer() {
 
   const { scheduledEvents: eqEvents, refresh: refreshEquipments } =
     useEquipmentScheduledEvents({
-      equipmentIds: getEquipmentIdsFromQuery(queryEquipment),
+      equipmentIds: getArrayOfIdsFromQuery(queryEquipment),
       startsAt: filter.startsAt,
       endsAt: filter.endsAt,
     });
@@ -336,8 +327,8 @@ export default function CalendarViewContainer() {
     const newStartDate = getStartDate();
     setFilter(
       generateScheduledEventFilter(
-        getInstrumentIdsFromQuery(queryInstrument),
-        getEquipmentIdsFromQuery(queryLocalContact),
+        getArrayOfIdsFromQuery(queryInstrument),
+        getArrayOfIdsFromQuery(queryLocalContact),
         newStartDate,
         queryView || view
       )
@@ -676,7 +667,7 @@ export default function CalendarViewContainer() {
               <ScheduledEventDialog
                 selectedEvent={selectedEvent}
                 selectedInstrumentId={
-                  getInstrumentIdsFromQuery(queryInstrument)[0] || 0
+                  getArrayOfIdsFromQuery(queryInstrument)[0] || 0
                 }
                 isDialogOpen={selectedEvent !== null}
                 closeDialog={closeDialog}

--- a/src/components/calendar/CalendarViewContainer.tsx
+++ b/src/components/calendar/CalendarViewContainer.tsx
@@ -110,6 +110,7 @@ const transformEvent = (
     scheduledBy: scheduledEvent.scheduledBy,
     status: scheduledEvent.status,
     statusTableRenderValue: ScheduledEventStatusMap[scheduledEvent.status],
+    localContact: scheduledEvent.localContact,
   }));
 
 const useStyles = makeStyles((theme) => ({
@@ -213,6 +214,7 @@ export default function CalendarViewContainer() {
   const querySchedulerView = query.get('schedulerView');
   const queryView = query.get('viewPeriod') as SchedulerViewPeriod;
   const queryStartsAt = query.get('startsAt');
+  const queryLocalContact = query.get('localContact');
 
   const [schedulerActiveView, setSchedulerActiveView] = useState(
     (querySchedulerView as SchedulerViews) || SchedulerViews.CALENDAR
@@ -238,6 +240,7 @@ export default function CalendarViewContainer() {
   const [filter, setFilter] = useState(
     generateScheduledEventFilter(
       getInstrumentIdsFromQuery(queryInstrument),
+      getEquipmentIdsFromQuery(queryLocalContact),
       startsAt,
       view
     )
@@ -334,12 +337,13 @@ export default function CalendarViewContainer() {
     setFilter(
       generateScheduledEventFilter(
         getInstrumentIdsFromQuery(queryInstrument),
+        getEquipmentIdsFromQuery(queryLocalContact),
         newStartDate,
         queryView || view
       )
     );
     setView(queryView || view);
-  }, [queryInstrument, view, getStartDate, queryView]);
+  }, [queryInstrument, queryLocalContact, view, getStartDate, queryView]);
 
   const equipmentEventsTransformed: GetScheduledEventsQuery['scheduledEvents'] =
     eqEvents

--- a/src/components/calendar/Event.tsx
+++ b/src/components/calendar/Event.tsx
@@ -5,6 +5,7 @@ import { EventProps } from 'react-big-calendar';
 import EquipmentBookingInfo from 'components/equipment/EquipmentBookingInfo';
 import ProposalBookingInfo from 'components/proposalBooking/ProposalBookingInfo';
 import {
+  BasicUserDetailsFragment,
   GetScheduledEventsQuery,
   ProposalBooking,
   ProposalBookingStatusCore,
@@ -25,6 +26,10 @@ export type CalendarScheduledEvent = Pick<
   | 'equipmentId'
   | 'status'
 > & {
+  localContact: Pick<
+    BasicUserDetailsFragment,
+    'id' | 'firstname' | 'lastname'
+  > | null;
   start: Date;
   startTableRenderValue: string;
   end: Date;

--- a/src/components/calendar/InstrumentAndEquipmentFilter.tsx
+++ b/src/components/calendar/InstrumentAndEquipmentFilter.tsx
@@ -17,10 +17,7 @@ import { useQuery } from 'hooks/common/useQuery';
 import { PartialInstrument } from 'hooks/instrument/useUserInstruments';
 import { getFullUserName } from 'utils/user';
 
-import {
-  getEquipmentIdsFromQuery,
-  getInstrumentIdsFromQuery,
-} from './CalendarViewContainer';
+import { getArrayOfIdsFromQuery } from './CalendarViewContainer';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -67,7 +64,7 @@ export default function InstrumentAndEquipmentFilter({
   >([]);
 
   useEffect(() => {
-    const equipmentIds = getEquipmentIdsFromQuery(queryEquipment);
+    const equipmentIds = getArrayOfIdsFromQuery(queryEquipment);
 
     if (!loadingEquipments && equipmentIds.length && equipments.length) {
       const queryFilteredEquipments = equipments.filter((eq) =>
@@ -79,7 +76,7 @@ export default function InstrumentAndEquipmentFilter({
   }, [loadingEquipments, equipments, queryEquipment]);
 
   useEffect(() => {
-    const queryInstrumentIds = getInstrumentIdsFromQuery(queryInstrument);
+    const queryInstrumentIds = getArrayOfIdsFromQuery(queryInstrument);
 
     if (!loadingInstruments && queryInstrumentIds.length) {
       const queryFoundInstruments = instruments.filter((item) =>
@@ -94,7 +91,7 @@ export default function InstrumentAndEquipmentFilter({
   }, [loadingInstruments, instruments, queryInstrument, multipleInstruments]);
 
   useEffect(() => {
-    const localContactIds = getEquipmentIdsFromQuery(queryLocalContacts);
+    const localContactIds = getArrayOfIdsFromQuery(queryLocalContacts);
 
     if (!loadingLocalContacts && localContactIds.length) {
       const queryFilteredLocalContacts = localContacts.filter((eq) =>

--- a/src/components/calendar/InstrumentAndEquipmentFilter.tsx
+++ b/src/components/calendar/InstrumentAndEquipmentFilter.tsx
@@ -15,6 +15,7 @@ import { InstrumentAndEquipmentContext } from 'context/InstrumentAndEquipmentCon
 import { BasicUserDetailsFragment, Equipment } from 'generated/sdk';
 import { useQuery } from 'hooks/common/useQuery';
 import { PartialInstrument } from 'hooks/instrument/useUserInstruments';
+import { getFullUserName } from 'utils/user';
 
 import {
   getEquipmentIdsFromQuery,
@@ -22,8 +23,12 @@ import {
 } from './CalendarViewContainer';
 
 const useStyles = makeStyles((theme) => ({
-  tooltip: {
+  root: {
     marginBottom: theme.spacing(1),
+
+    '& .MuiAutocomplete-tag': {
+      width: 'calc(100% - 65px)',
+    },
   },
 }));
 
@@ -46,7 +51,7 @@ export default function InstrumentAndEquipmentFilter({
   } = useContext(InstrumentAndEquipmentContext);
   const queryInstrument = query.get('instrument');
   const queryEquipment = query.get('equipment');
-  const queryLocalContacts = query.get('localContacts');
+  const queryLocalContacts = query.get('localContact');
 
   const [selectedInstrument, setSelectedInstrument] = useState<
     PartialInstrument | PartialInstrument[] | null
@@ -179,13 +184,13 @@ export default function InstrumentAndEquipmentFilter({
       newSelectedLocalContacts === undefined ||
       newSelectedLocalContacts.length === 0
     ) {
-      query.delete('localContacts');
+      query.delete('localContact');
     } else if (
       JSON.stringify(newSelectedLocalContacts) !==
       JSON.stringify(selectedLocalContacts)
     ) {
       query.set(
-        'localContacts',
+        'localContact',
         `${newSelectedLocalContacts?.map((lc) => lc.id).join(',')}`
       );
     }
@@ -221,14 +226,14 @@ export default function InstrumentAndEquipmentFilter({
     <Grid
       container
       alignItems="center"
-      className={`${classes.tooltip}`}
+      className={`${classes.root}`}
       spacing={2}
     >
-      <Grid item sm={6} xs={12} data-cy="calendar-toolbar-instrument-select">
+      <Grid item sm={4} xs={12} data-cy="calendar-toolbar-instrument-select">
         <Autocomplete
           multiple={multipleInstruments}
           renderTags={(value, getTagProps) =>
-            renderLimitedTags({ value, getTagProps, limitTags: 2 })
+            renderLimitedTags({ value, getTagProps, limitTags: 1 })
           }
           loading={loadingInstruments}
           disabled={loadingInstruments}
@@ -264,7 +269,7 @@ export default function InstrumentAndEquipmentFilter({
           onChange={onInstrumentChange}
         />
       </Grid>
-      <Grid item sm={6} xs={12} data-cy="calendar-toolbar-equipment-select">
+      <Grid item sm={4} xs={12} data-cy="calendar-toolbar-equipment-select">
         <Autocomplete
           multiple
           renderTags={(value, getTagProps) =>
@@ -304,12 +309,19 @@ export default function InstrumentAndEquipmentFilter({
           onChange={onEquipmentChange}
         />
       </Grid>
-      <Grid item sm={6} xs={12} data-cy="calendar-toolbar-equipment-select">
+      <Grid item sm={4} xs={12} data-cy="calendar-toolbar-equipment-select">
         <Autocomplete
           multiple
-          // renderTags={(value, getTagProps) =>
-          //   renderLimitedTags({ value, getTagProps, limitTags: 1 })
-          // }
+          renderTags={(value, getTagProps) =>
+            renderLimitedTags({
+              value: value.map((item) => ({
+                id: item.id,
+                name: getFullUserName(item),
+              })),
+              getTagProps,
+              limitTags: 1,
+            })
+          }
           loading={loadingLocalContacts}
           disabled={loadingLocalContacts}
           selectOnFocus

--- a/src/components/calendar/InstrumentAndEquipmentFilter.tsx
+++ b/src/components/calendar/InstrumentAndEquipmentFilter.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Chip,
   CircularProgress,
   Grid,
@@ -207,14 +208,26 @@ export default function InstrumentAndEquipmentFilter({
     limitTags: number;
   }) => {
     const numTags = value.length;
+    const itemsInsideTheLimit = value.slice(0, limitTags);
+    const itemsOutsideTheLimit = value.slice(limitTags);
 
     return (
       <>
-        {value.slice(0, limitTags).map((option, index) => (
-          <Chip {...getTagProps({ index })} key={index} label={option.name} />
+        {itemsInsideTheLimit.map((option, index) => (
+          <Chip
+            {...getTagProps({ index })}
+            key={index}
+            label={option.name}
+            title={option.name}
+          />
         ))}
 
-        {numTags > limitTags && ` +${numTags - limitTags}`}
+        <Box
+          title={itemsOutsideTheLimit.map((item) => item.name).join(', ')}
+          component="span"
+        >
+          {numTags > limitTags && ` +${numTags - limitTags}`}
+        </Box>
       </>
     );
   };

--- a/src/components/calendar/TimeLineView.tsx
+++ b/src/components/calendar/TimeLineView.tsx
@@ -1,4 +1,4 @@
-import { makeStyles, Tooltip } from '@material-ui/core';
+import { Box, makeStyles } from '@material-ui/core';
 import * as H from 'history';
 import { debounce } from 'lodash';
 import moment from 'moment';
@@ -126,9 +126,13 @@ const useStyles = makeStyles((theme) => ({
       '& .rct-sidebar .rct-sidebar-row': {
         padding: 0,
 
+        '& .title': {
+          paddingLeft: theme.spacing(1),
+        },
+
         '& .custom-group': {
           background: 'lightgray',
-          padding: '0 4px',
+          padding: theme.spacing(0, 0.5),
           textTransform: 'capitalize',
         },
       },
@@ -346,9 +350,13 @@ const TimeLineView: React.FC<TimeLineViewProps> = ({
                 {openGroups[group.id] ? '[-]' : '[+]'} <b>{group.title}</b>
               </div>
             ) : (
-              <div className="rct-sidebar-row" style={{ paddingLeft: 10 }}>
-                {group.title}
-              </div>
+              <Box
+                title={group.title}
+                component="div"
+                className="rct-sidebar-row"
+              >
+                <span className="title">{group.title}</span>
+              </Box>
             ),
           };
         })
@@ -368,15 +376,11 @@ const TimeLineView: React.FC<TimeLineViewProps> = ({
       />
       <Timeline
         groups={timeLineGroupsWithCustomTitle}
-        groupRenderer={({ group }) => {
-          return group.root ? (
-            <div className="custom-group">{group.title}</div>
-          ) : (
-            <Tooltip title={group.title} style={{ top: '-40px' }}>
-              <div className="title">{group.title}</div>
-            </Tooltip>
-          );
-        }}
+        groupRenderer={({ group }) => (
+          <div className={`${group.root ? 'custom-group' : ''}`}>
+            {group.title}
+          </div>
+        )}
         items={timelineEvents}
         visibleTimeStart={visibleTimeStart.valueOf()}
         visibleTimeEnd={visibleTimeEnd.valueOf()}

--- a/src/components/calendar/TimeLineView.tsx
+++ b/src/components/calendar/TimeLineView.tsx
@@ -354,6 +354,7 @@ const TimeLineView: React.FC<TimeLineViewProps> = ({
                 title={group.title}
                 component="div"
                 className="rct-sidebar-row"
+                data-cy="item-group"
               >
                 <span className="title">{group.title}</span>
               </Box>

--- a/src/context/InstrumentAndEquipmentContext.tsx
+++ b/src/context/InstrumentAndEquipmentContext.tsx
@@ -1,15 +1,19 @@
 import React from 'react';
 
+import { BasicUserDetailsFragment, UserRole } from 'generated/sdk';
 import useEquipments, { PartialEquipment } from 'hooks/equipment/useEquipments';
 import useUserInstruments, {
   PartialInstrument,
 } from 'hooks/instrument/useUserInstruments';
+import { useUsersData } from 'hooks/user/useUsersData';
 
 interface InstrumentAndEquipmentContextData {
   readonly instruments: PartialInstrument[];
   readonly loadingInstruments: boolean;
   readonly equipments: PartialEquipment[];
   readonly loadingEquipments: boolean;
+  readonly localContacts: BasicUserDetailsFragment[];
+  readonly loadingLocalContacts: boolean;
 }
 
 const initialInstrumentAndEquipmentData: InstrumentAndEquipmentContextData = {
@@ -17,6 +21,8 @@ const initialInstrumentAndEquipmentData: InstrumentAndEquipmentContextData = {
   loadingInstruments: false,
   equipments: [],
   loadingEquipments: false,
+  localContacts: [],
+  loadingLocalContacts: false,
 };
 
 export const InstrumentAndEquipmentContext =
@@ -27,10 +33,20 @@ export const InstrumentAndEquipmentContext =
 export const InstrumentAndEquipmentContextProvider: React.FC = (props) => {
   const { instruments, loading: loadingInstruments } = useUserInstruments();
   const { equipments, loading: loadingEquipments } = useEquipments();
+  const { usersData, loadingUsersData } = useUsersData({
+    userRole: UserRole.INSTRUMENT_SCIENTIST,
+  });
 
   return (
     <InstrumentAndEquipmentContext.Provider
-      value={{ instruments, loadingInstruments, equipments, loadingEquipments }}
+      value={{
+        instruments,
+        loadingInstruments,
+        equipments,
+        loadingEquipments,
+        localContacts: usersData.users,
+        loadingLocalContacts: loadingUsersData,
+      }}
     >
       {props.children}
     </InstrumentAndEquipmentContext.Provider>

--- a/src/filters/scheduledEvent/scheduledEventsFilter.ts
+++ b/src/filters/scheduledEvent/scheduledEventsFilter.ts
@@ -6,17 +6,17 @@ import { toTzLessDateTime } from 'utils/date';
 
 export default function generateScheduledEventFilter(
   instrumentIds: number[],
+  localContactIds: number[],
   startsAt: Date,
   activeView: View
 ): ScheduledEventFilter {
-  instrumentIds = instrumentIds?.length ? instrumentIds : [0];
-
   switch (activeView) {
     case 'day': {
       const newStartsAt = moment(startsAt);
 
       return {
         instrumentIds,
+        localContactIds,
         startsAt: toTzLessDateTime(newStartsAt),
         endsAt: toTzLessDateTime(newStartsAt.add(1, 'day')),
       };
@@ -26,6 +26,7 @@ export default function generateScheduledEventFilter(
 
       return {
         instrumentIds,
+        localContactIds,
         startsAt: toTzLessDateTime(newStartsAt),
         endsAt: toTzLessDateTime(newStartsAt.add(1, 'week')),
       };
@@ -35,6 +36,7 @@ export default function generateScheduledEventFilter(
 
       return {
         instrumentIds,
+        localContactIds,
         startsAt: toTzLessDateTime(newStartsAt),
         endsAt: toTzLessDateTime(newStartsAt.add(1, 'month')),
       };
@@ -47,6 +49,7 @@ export default function generateScheduledEventFilter(
         startsAt: toTzLessDateTime(newStartsAt),
         endsAt: toTzLessDateTime(newStartsAt.add(1, 'week')),
         instrumentIds,
+        localContactIds,
       };
   }
 }

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -2131,6 +2131,8 @@ export type ProposalView = {
   statusId: Scalars['Int'];
   statusName: Scalars['String'];
   submitted: Scalars['Boolean'];
+  technicalReviewAssignee: Maybe<Scalars['Int']>;
+  technicalReviewSubmitted: Maybe<Scalars['Int']>;
   technicalStatus: Maybe<TechnicalReviewStatus>;
   technicalTimeAllocation: Maybe<Scalars['Int']>;
   title: Scalars['String'];
@@ -2198,6 +2200,12 @@ export type ProposalsResponseWrap = {
   rejection: Maybe<Rejection>;
 };
 
+export type ProposalsViewResult = {
+  __typename?: 'ProposalsViewResult';
+  proposals: Array<ProposalView>;
+  totalCount: Scalars['Int'];
+};
+
 export type QueriesAndMutations = {
   __typename?: 'QueriesAndMutations';
   mutations: Array<Scalars['String']>;
@@ -2239,7 +2247,7 @@ export type Query = {
   instrumentProposalBookings: Array<ProposalBooking>;
   instrumentScientistHasAccess: Maybe<Scalars['Boolean']>;
   instrumentScientistHasInstrument: Maybe<Scalars['Boolean']>;
-  instrumentScientistProposals: Maybe<ProposalsQueryResult>;
+  instrumentScientistProposals: Maybe<ProposalsViewResult>;
   instruments: Maybe<InstrumentsQueryResult>;
   instrumentsBySep: Maybe<Array<InstrumentWithAvailabilityTime>>;
   isNaturalKeyPresent: Maybe<Scalars['Boolean']>;
@@ -3036,7 +3044,8 @@ export type ScheduledEventCore = {
 
 export type ScheduledEventFilter = {
   endsAt: Scalars['TzLessDateTime'];
-  instrumentIds?: Maybe<Array<Scalars['Int']>>;
+  instrumentIds: Array<Scalars['Int']>;
+  localContactIds: Array<Scalars['Int']>;
   startsAt: Scalars['TzLessDateTime'];
 };
 
@@ -4122,7 +4131,7 @@ export type GetScheduledEventsQuery = (
       & Pick<User, 'firstname' | 'lastname'>
     )>, localContact: Maybe<(
       { __typename?: 'User' }
-      & Pick<User, 'firstname' | 'lastname'>
+      & Pick<User, 'id' | 'firstname' | 'lastname'>
     )>, proposalBooking: Maybe<(
       { __typename?: 'ProposalBooking' }
       & Pick<ProposalBooking, 'id' | 'createdAt' | 'updatedAt' | 'status' | 'allocatedTime'>
@@ -4189,7 +4198,7 @@ export type UpdateScheduledEventMutation = (
       & Pick<ScheduledEvent, 'id' | 'startsAt' | 'endsAt'>
       & { localContact: Maybe<(
         { __typename?: 'User' }
-        & Pick<User, 'firstname' | 'lastname'>
+        & Pick<User, 'id' | 'firstname' | 'lastname'>
       )> }
     )> }
   ) }
@@ -4762,6 +4771,7 @@ export const GetScheduledEventsDocument = gql`
       lastname
     }
     localContact {
+      id
       firstname
       lastname
     }
@@ -4830,6 +4840,7 @@ export const UpdateScheduledEventDocument = gql`
       startsAt
       endsAt
       localContact {
+        id
         firstname
         lastname
       }

--- a/src/graphql/scheduledEvent/getScheduledEvents.graphql
+++ b/src/graphql/scheduledEvent/getScheduledEvents.graphql
@@ -19,6 +19,7 @@ query getScheduledEvents(
       lastname
     }
     localContact {
+      id
       firstname
       lastname
     }

--- a/src/graphql/scheduledEvent/updateScheduledEvent.graphql
+++ b/src/graphql/scheduledEvent/updateScheduledEvent.graphql
@@ -6,6 +6,7 @@ mutation updateScheduledEvent($input: UpdateScheduledEventInput!) {
       startsAt
       endsAt
       localContact {
+        id
         firstname
         lastname
       }

--- a/src/hooks/scheduledEvent/useScheduledEvents.ts
+++ b/src/hooks/scheduledEvent/useScheduledEvents.ts
@@ -7,6 +7,7 @@ export default function useScheduledEvents({
   endsAt,
   startsAt,
   instrumentIds,
+  localContactIds,
 }: ScheduledEventFilter) {
   const [loading, setLoading] = useState(true);
   const [scheduledEvents, setScheduledEvents] = useState<
@@ -18,6 +19,7 @@ export default function useScheduledEvents({
   const [counter, setCounter] = useState<number>(0);
   // NOTE: We need to stringify the ids array before we pass it to the useEffect dependency array because of its comparison.
   const instrumentIdsStringified = JSON.stringify(instrumentIds);
+  const localContactIdsStringified = JSON.stringify(localContactIds);
 
   const api = useDataApi();
 
@@ -28,10 +30,11 @@ export default function useScheduledEvents({
   useEffect(() => {
     let unmount = false;
     const instrumentIdsArray = JSON.parse(instrumentIdsStringified);
+    const localContactIdsArray = JSON.parse(localContactIdsStringified);
 
     setLoading(true);
 
-    if (!instrumentIdsArray?.length) {
+    if (!instrumentIdsArray?.length && !localContactIdsArray?.length) {
       setScheduledEvents([]);
       setLoading(false);
 
@@ -40,7 +43,12 @@ export default function useScheduledEvents({
 
     api()
       .getScheduledEvents({
-        filter: { startsAt, endsAt, instrumentIds: instrumentIdsArray },
+        filter: {
+          startsAt,
+          endsAt,
+          instrumentIds: instrumentIdsArray,
+          localContactIds: localContactIdsArray,
+        },
         scheduledEventFilter: {},
       })
       .then((data) => {
@@ -58,7 +66,14 @@ export default function useScheduledEvents({
     return () => {
       unmount = true;
     };
-  }, [counter, startsAt, endsAt, instrumentIdsStringified, api]);
+  }, [
+    counter,
+    startsAt,
+    endsAt,
+    instrumentIdsStringified,
+    localContactIdsStringified,
+    api,
+  ]);
 
   return {
     loading,

--- a/src/hooks/user/useUsersData.ts
+++ b/src/hooks/user/useUsersData.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+
+import {
+  BasicUserDetailsFragment,
+  GetUsersQueryVariables,
+} from 'generated/sdk';
+import { useDataApi } from 'hooks/common/useDataApi';
+
+export function useUsersData(
+  usersFilter: GetUsersQueryVariables & { refreshData?: boolean }
+) {
+  const { filter, offset, first, subtractUsers, userRole, refreshData } =
+    usersFilter;
+  const [usersData, setUsersData] = useState<{
+    totalCount: number;
+    users: Array<BasicUserDetailsFragment>;
+  }>({
+    totalCount: 0,
+    users: [],
+  });
+  const [loadingUsersData, setLoading] = useState(true);
+
+  const api = useDataApi();
+  useEffect(() => {
+    let unmounted = false;
+
+    setLoading(true);
+    api()
+      .getUsers({
+        filter,
+        offset,
+        subtractUsers,
+        first,
+        userRole,
+      })
+      .then((data) => {
+        if (unmounted) {
+          return;
+        }
+
+        setUsersData(data.users || { totalCount: 0, users: [] });
+        setLoading(false);
+      });
+
+    return () => {
+      unmounted = true;
+    };
+  }, [filter, offset, subtractUsers, first, userRole, api, refreshData]);
+
+  return { loadingUsersData, usersData, setUsersData };
+}


### PR DESCRIPTION
## Description

This adds ability to get and see scheduled events on local contacts even if there is no instrument selected. Tests are failing mainly because it depends on the https://github.com/UserOfficeProject/user-office-backend/pull/510 PR.

## Motivation and Context

After we added the local contact assignment on the scheduled event we would like to see how the local contacts are booked which is represented the best in the timeline view.

## How Has This Been Tested

- e2e test
- manual testing

## Fixes

- https://jira.esss.lu.se/browse/SWAP-2016
- https://jira.esss.lu.se/browse/SWAP-2089

## Changes

https://user-images.githubusercontent.com/6333063/145988996-a07ef27b-cec6-4b17-aaf8-c02f60e9a439.mp4

## Depends on

- https://github.com/UserOfficeProject/user-office-backend/pull/510
- https://github.com/UserOfficeProject/user-office-scheduler-backend/pull/110

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated