### PR TITLE
SWAP-2079-proposal-booking-modal-refactor

### DIFF
--- a/cypress/integration/proposal-booking.spec.ts
+++ b/cypress/integration/proposal-booking.spec.ts
@@ -185,7 +185,7 @@ context('Proposal booking tests ', () => {
           .first()
           .click();
 
-        cy.get('.MuiTab-fullWidth').last().click();
+        cy.get('[id^=vertical-tab-]').last().click();
 
         cy.contains(getHourDateTimeAfter(2, 'days'));
         cy.contains(getHourDateTimeAfter(3, 'days'));
@@ -317,7 +317,7 @@ context('Proposal booking tests ', () => {
         ).should('not.exist');
 
         cy.finishedLoading();
-        cy.get('.MuiTab-fullWidth').last().click();
+        cy.get('[id^=vertical-tab-]').last().click();
 
         cy.get('[data-cy="event-outside-cycle-interval-warning"]').should(
           'not.exist'
@@ -507,7 +507,9 @@ context('Proposal booking tests ', () => {
         cy.get('[data-cy="btn-ok"]').click();
         cy.finishedLoading();
 
-        cy.contains(/No records to display\. Start by adding new time slot/i);
+        cy.contains(
+          /No records to display\. Start by adding new experiment time/i
+        );
       });
 
       it('should show warning when `startsAt` is after `endsAt`', () => {
@@ -1064,16 +1066,24 @@ context('Proposal booking tests ', () => {
         cy.contains(/you have overlapping events/i);
       });
 
-      it('should be able to complete the booking process', () => {
+      it('should be able to complete the time slot booking process', () => {
         cy.finishedLoading();
         selectInstrumentAndClickOnProposalForBooking();
         cy.finishedLoading();
 
-        cy.contains(/complete proposal booking/i).as('completeBooking');
+        cy.contains(/complete the time slot booking/i).as(
+          'completeTimeSlotBooking'
+        );
 
-        cy.get('@completeBooking').should('not.be.disabled').click();
+        cy.get('@completeTimeSlotBooking')
+          .scrollIntoView()
+          .should('not.be.disabled')
+          .click();
         cy.get('[data-cy="btn-ok"]').click();
 
+        cy.contains(
+          /Time slot booking is already completed, you can not edit it/i
+        );
         cy.contains(
           /Proposal booking is already completed, you can not edit it/i
         );
@@ -1161,9 +1171,7 @@ context('Proposal booking tests ', () => {
           .first()
           .click();
 
-        cy.get('[data-cy="btn-reopen-booking"]').should('not.exist');
-
-        cy.get('.MuiTab-fullWidth').first().click();
+        cy.get('#vertical-tab-0').click();
 
         cy.finishedLoading();
 
@@ -1198,12 +1206,7 @@ context('Proposal booking tests ', () => {
           .first()
           .click();
 
-        cy.get('[data-cy="btn-reopen-booking"]').should(
-          'include.text',
-          'Reopen proposal booking'
-        );
-
-        cy.get('.MuiTab-fullWidth').first().click();
+        cy.get('#vertical-tab-0').click();
 
         cy.finishedLoading();
 
@@ -1218,10 +1221,8 @@ context('Proposal booking tests ', () => {
 
         cy.finishedLoading();
 
-        cy.get('[title="Add lost time"]').should('exist');
+        cy.get('[title="Add experiment lost time"]').should('exist');
         cy.contains('Complete the time slot booking');
-
-        cy.get('[data-cy="btn-reopen-booking"]').should('not.exist');
       });
     });
   });

--- a/src/components/common/SimpleTabs.tsx
+++ b/src/components/common/SimpleTabs.tsx
@@ -1,10 +1,15 @@
-import { Button, Paper, useMediaQuery } from '@material-ui/core';
+import {
+  Button,
+  CircularProgress,
+  Paper,
+  useMediaQuery,
+} from '@material-ui/core';
 import Box from '@material-ui/core/Box';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
 import { Add as AddIcon } from '@material-ui/icons';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
 interface TabPanelProps {
   children?: React.ReactNode;
@@ -52,6 +57,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     flexGrow: 1,
     backgroundColor: theme.palette.background.paper,
     display: 'flex',
+    minHeight: '500px',
   },
   rootHeightLimit: {
     height: '500px', // NOTE: When orientation is vertical we limit the height to have better user experience
@@ -62,12 +68,19 @@ const useStyles = makeStyles((theme: Theme) => ({
     backgroundColor: theme.palette.grey['100'],
     boxShadow: theme.shadows[1],
   },
+  tabsNoItems: {
+    minWidth: '150px',
+  },
   tabsRightBorder: {
     borderRight: `1px solid ${theme.palette.divider}`,
   },
   addButton: {
-    minWidth: '190px',
+    minWidth: 'auto',
     padding: theme.spacing(1),
+
+    '&.Mui-disabled': {
+      pointerEvents: 'all',
+    },
   },
 }));
 
@@ -81,8 +94,10 @@ const SimpleTabs: React.FC<SimpleTabsProps> = ({
 }) => {
   const isMobile = useMediaQuery('(max-width: 500px)');
   const classes = useStyles();
-  const [value, setValue] = React.useState(tab || 0);
+  const [value, setValue] = useState(tab || 0);
+  const [isAddingNewItem, setIsAddingNewItem] = useState(false);
   const isExtraLargeScreen = useMediaQuery('(min-height: 1200px)');
+  const noItems = children.length === 0;
 
   // NOTE: If screen is mobile use horizontal orientation for space optimization
   if (isMobile) {
@@ -102,12 +117,20 @@ const SimpleTabs: React.FC<SimpleTabsProps> = ({
     setValue(newValue);
   };
 
+  const handleAddNew = async () => {
+    setIsAddingNewItem(true);
+    // NOTE: We have a check for this in the code and handleAddNew button is not visible if handleAdd is not defined.
+    await handleAdd?.();
+    setIsAddingNewItem(false);
+  };
+
   // NOTE: If screen is extra large do not limit the tabs height for space optimization
   const rootClasses = isExtraLargeScreen
     ? classes.root
     : `${classes.root} ${classes.rootHeightLimit}`;
-
-  const noItems = children.length === 0;
+  const tabsClasses = `${classes.tabs} ${
+    isVerticalOrientation && classes.tabsRightBorder
+  } ${noItems && classes.tabsNoItems}`;
 
   return (
     <Paper elevation={3} className={isVerticalOrientation ? rootClasses : ''}>
@@ -120,25 +143,35 @@ const SimpleTabs: React.FC<SimpleTabsProps> = ({
         aria-label={`${orientation} tabs example`}
         indicatorColor="primary"
         orientation={orientation}
-        className={`${classes.tabs} ${
-          isVerticalOrientation ? classes.tabsRightBorder : ''
-        }`}
+        className={tabsClasses}
       >
         {tabNames.map((tabName, i) => (
           <Tab key={i} label={tabName} {...a11yProps(i, orientation)} />
         ))}
         {!!handleAdd && (
-          <div className={`MuiTab-root ${noItems && classes.addButton}`}>
-            <Button
-              variant="outlined"
-              color="primary"
-              onClick={handleAdd}
-              startIcon={<AddIcon />}
-              data-cy="add-new-timeslot"
-            >
-              Add time
-            </Button>
-          </div>
+          <Tab
+            className={classes.addButton}
+            disabled
+            label={
+              <Button
+                variant="outlined"
+                color="primary"
+                component="span"
+                onClick={handleAddNew}
+                disabled={isAddingNewItem}
+                startIcon={
+                  isAddingNewItem ? (
+                    <CircularProgress size={20} color="inherit" />
+                  ) : (
+                    <AddIcon />
+                  )
+                }
+                data-cy="add-new-timeslot"
+              >
+                Add time
+              </Button>
+            }
+          />
         )}
       </Tabs>
 

--- a/src/components/common/SimpleTabs.tsx
+++ b/src/components/common/SimpleTabs.tsx
@@ -1,10 +1,9 @@
 import { Paper } from '@material-ui/core';
-import AppBar from '@material-ui/core/AppBar';
+// import AppBar from '@material-ui/core/AppBar';
 import Box from '@material-ui/core/Box';
-import useTheme from '@material-ui/core/styles/useTheme';
+import { makeStyles, Theme } from '@material-ui/core/styles';
 import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
-import Typography from '@material-ui/core/Typography';
 import React, { useEffect } from 'react';
 
 interface TabPanelProps {
@@ -18,42 +17,53 @@ function TabPanel(props: TabPanelProps) {
   const { children, value, index, ...other } = props;
 
   return (
-    <Typography
-      component="div"
+    <Box
       role="tabpanel"
       hidden={value !== index}
-      id={`full-width-tabpanel-${index}`}
-      aria-labelledby={`full-width-tab-${index}`}
+      id={`vertical-tabpanel-${index}`}
+      aria-labelledby={`vertical-tab-${index}`}
+      width="100%"
       {...other}
     >
-      {value === index && (
-        <Box p={3} position="relative" minHeight={200}>
-          {children}
-        </Box>
-      )}
-    </Typography>
+      {value === index && <Box p={3}>{children}</Box>}
+    </Box>
   );
 }
 
 function a11yProps(index: number) {
   return {
-    id: `full-width-tab-${index}`,
-    'aria-controls': `full-width-tabpanel-${index}`,
+    id: `vertical-tab-${index}`,
+    'aria-controls': `vertical-tabpanel-${index}`,
   };
 }
 
-type FullWidthTabsProps = {
+type VerticalTabsProps = {
   children: React.ReactNode[];
   tab?: number;
   tabNames: string[];
 };
 
-const FullWidthTabs: React.FC<FullWidthTabsProps> = ({
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    flexGrow: 1,
+    backgroundColor: theme.palette.background.paper,
+    display: 'flex',
+  },
+  tabs: {
+    borderRight: `1px solid ${theme.palette.divider}`,
+    width: 'auto',
+    flexShrink: 2,
+  },
+}));
+
+// TODO: Work a bit on the mobile view because the tab controls are not visible when screen is too small.
+// Maybe it will be good to show controls on top when mobile or somehow make it a bit better when it comes to responsiveness
+const VerticalTabs: React.FC<VerticalTabsProps> = ({
   tabNames,
   children,
   tab,
 }) => {
-  const theme = useTheme();
+  const classes = useStyles();
   const [value, setValue] = React.useState(tab || 0);
 
   useEffect(() => {
@@ -68,24 +78,26 @@ const FullWidthTabs: React.FC<FullWidthTabsProps> = ({
   };
 
   return (
-    <Paper elevation={3}>
-      <AppBar position="static" color="default">
-        <Tabs
-          value={value}
-          textColor="primary"
-          variant="fullWidth"
-          onChange={handleChange}
-          aria-label="full width tabs example"
-          indicatorColor="primary"
-        >
-          {tabNames.map((tabName, i) => (
-            <Tab key={i} label={tabName} {...a11yProps(i)} />
-          ))}
-        </Tabs>
-      </AppBar>
+    <Paper elevation={3} className={classes.root}>
+      {/* <AppBar position="static" color="default" > */}
+      <Tabs
+        value={value}
+        textColor="primary"
+        variant="scrollable"
+        onChange={handleChange}
+        aria-label="Vertical tabs example"
+        indicatorColor="primary"
+        orientation="vertical"
+        className={classes.tabs}
+      >
+        {tabNames.map((tabName, i) => (
+          <Tab key={i} label={tabName} {...a11yProps(i)} />
+        ))}
+      </Tabs>
+      {/* </AppBar> */}
 
       {children.map((tabContent, i) => (
-        <TabPanel key={i} value={value} index={i} dir={theme.direction}>
+        <TabPanel key={i} value={value} index={i}>
           {tabContent}
         </TabPanel>
       ))}
@@ -93,4 +105,4 @@ const FullWidthTabs: React.FC<FullWidthTabsProps> = ({
   );
 };
 
-export default FullWidthTabs;
+export default VerticalTabs;

--- a/src/components/proposalBooking/ProposalDetailsAndBookingEvents.tsx
+++ b/src/components/proposalBooking/ProposalDetailsAndBookingEvents.tsx
@@ -1,23 +1,21 @@
 import { getTranslation, ResourceId } from '@esss-swap/duo-localisation';
 import {
   Avatar,
-  Box,
-  Button,
-  CircularProgress,
   Divider,
   Grid,
+  ListItem,
   ListItemAvatar,
   ListItemText,
   makeStyles,
-  Paper,
   Typography,
 } from '@material-ui/core';
 import {
   Comment as CommentIcon,
-  CalendarToday as CalendarTodayIcon,
+  EventAvailable as EventAvailableIcon,
+  EventBusy as EventBusyIcon,
+  HourglassFull as HourglassFullIcon,
   HourglassEmpty as HourglassEmptyIcon,
   Description as DescriptionIcon,
-  Add as AddIcon,
   Person,
 } from '@material-ui/icons';
 import { Alert, AlertTitle } from '@material-ui/lab';
@@ -46,7 +44,6 @@ import { useDataApi } from 'hooks/common/useDataApi';
 import { InstrumentProposalBooking } from 'hooks/proposalBooking/useInstrumentProposalBookings';
 import { ProposalBookingScheduledEvent } from 'hooks/scheduledEvent/useProposalBookingScheduledEvents';
 import { ScheduledEventWithEquipments } from 'hooks/scheduledEvent/useScheduledEventWithEquipment';
-import { ButtonContainer } from 'styles/StyledComponents';
 import { toTzLessDateTime, TZ_LESS_DATE_TIME_FORMAT } from 'utils/date';
 import { getFullUserName } from 'utils/user';
 
@@ -87,7 +84,7 @@ const useStyles = makeStyles((theme) => ({
     marginBottom: theme.spacing(2),
   },
   timeSlotsTitle: {
-    marginRight: 'auto',
+    margin: theme.spacing(1, 0),
   },
   root: {
     '& .MuiToolbar-root button.MuiIconButton-root': {
@@ -135,7 +132,7 @@ export default function ProposalDetailsAndBookingEvents({
   setProposalBooking,
 }: ProposalDetailsAndBookingEventsProps) {
   const {
-    call: { startCycle, endCycle, cycleComment, shortCode: callShortCode },
+    call: { startCycle, endCycle, shortCode: callShortCode },
     proposal: { title, proposalId, proposer },
     instrument,
   } = proposalBooking;
@@ -144,7 +141,7 @@ export default function ProposalDetailsAndBookingEvents({
 
   const { scheduledEvents } = proposalBooking;
 
-  const isStepReadOnly = scheduledEvents.length
+  const isProposalBookingCompleted = scheduledEvents.length
     ? scheduledEvents.every(
         (scheduledEvent) =>
           scheduledEvent.status === ProposalBookingStatusCore.COMPLETED
@@ -196,57 +193,59 @@ export default function ProposalDetailsAndBookingEvents({
   }, [scheduledEvents, startCycle, endCycle]);
 
   const handleAdd = async () => {
-    setIsAddingNewTimeSlot(true);
-    const lastRow =
-      scheduledEvents.length > 0
-        ? scheduledEvents[scheduledEvents.length - 1]
-        : undefined;
-    const startsAt = lastRow?.endsAt
-      ? moment(lastRow?.endsAt)
-      : moment().set({ hour: 9, minute: 0, second: 0 }); // NOTE: Start events at 9.00 AM for easier date modifications
-    const endsAt = startsAt.clone().add(1, 'day');
+    if (!isAddingNewTimeSlot) {
+      setIsAddingNewTimeSlot(true);
+      const lastRow =
+        scheduledEvents.length > 0
+          ? scheduledEvents[scheduledEvents.length - 1]
+          : undefined;
+      const startsAt = lastRow?.endsAt
+        ? moment(lastRow?.endsAt)
+        : moment().set({ hour: 9, minute: 0, second: 0 }); // NOTE: Start events at 9.00 AM for easier date modifications
+      const endsAt = startsAt.clone().add(1, 'day');
 
-    if (!instrument) {
-      return;
-    }
-
-    const {
-      createScheduledEvent: { error, scheduledEvent: createdScheduledEvent },
-    } = await api().createScheduledEvent({
-      input: {
-        proposalBookingId: proposalBooking.id,
-        bookingType: ScheduledEventBookingType.USER_OPERATIONS,
-        instrumentId: instrument.id,
-        startsAt: startsAt.format(TZ_LESS_DATE_TIME_FORMAT),
-        endsAt: endsAt.format(TZ_LESS_DATE_TIME_FORMAT),
-      },
-    });
-
-    if (error) {
-      enqueueSnackbar(getTranslation(error as ResourceId), {
-        variant: 'error',
-      });
-    } else {
-      enqueueSnackbar('Time slot added successfully', {
-        variant: 'success',
-      });
-
-      const newScheduledEvents = [
-        ...scheduledEvents,
-        createdScheduledEvent as ScheduledEvent,
-      ];
-
-      if (createdScheduledEvent) {
-        setProposalBooking({
-          ...proposalBooking,
-          scheduledEvents: newScheduledEvents,
-        });
-        // NOTE: Open the event right after creation
-        setSelectedTab(newScheduledEvents.length - 1);
+      if (!instrument) {
+        return;
       }
-    }
 
-    setIsAddingNewTimeSlot(false);
+      const {
+        createScheduledEvent: { error, scheduledEvent: createdScheduledEvent },
+      } = await api().createScheduledEvent({
+        input: {
+          proposalBookingId: proposalBooking.id,
+          bookingType: ScheduledEventBookingType.USER_OPERATIONS,
+          instrumentId: instrument.id,
+          startsAt: startsAt.format(TZ_LESS_DATE_TIME_FORMAT),
+          endsAt: endsAt.format(TZ_LESS_DATE_TIME_FORMAT),
+        },
+      });
+
+      if (error) {
+        enqueueSnackbar(getTranslation(error as ResourceId), {
+          variant: 'error',
+        });
+      } else {
+        enqueueSnackbar('Time slot added successfully', {
+          variant: 'success',
+        });
+
+        const newScheduledEvents = [
+          ...scheduledEvents,
+          createdScheduledEvent as ScheduledEvent,
+        ];
+
+        if (createdScheduledEvent) {
+          setProposalBooking({
+            ...proposalBooking,
+            scheduledEvents: newScheduledEvents,
+          });
+          // NOTE: Open the event right after creation
+          setSelectedTab(newScheduledEvents.length - 1);
+        }
+      }
+
+      setIsAddingNewTimeSlot(false);
+    }
   };
 
   const handleDelete = async (event: ScheduledEventWithEquipments) => {
@@ -288,207 +287,188 @@ export default function ProposalDetailsAndBookingEvents({
 
   return (
     <div className={classes.root}>
-      {isStepReadOnly && (
+      {isProposalBookingCompleted && (
         <Alert severity="info">
           Proposal booking is already completed, you can not edit it.
         </Alert>
       )}
 
       <Grid container spacing={2}>
-        <Grid item sm={6}>
-          <Typography variant="h6" component="h6" align="left">
+        <Grid item sm={12}>
+          <Typography variant="h6" component="h3" align="left">
             Proposal information
           </Typography>
           <Grid container alignItems="center">
-            <Grid item sm={1} xs={12}>
-              <ListItemAvatar>
-                <Avatar>
-                  <DescriptionIcon />
-                </Avatar>
-              </ListItemAvatar>
+            <Grid item xs={12} sm={4}>
+              <ListItem>
+                <ListItemAvatar>
+                  <Avatar>
+                    <IdentifierIcon />
+                  </Avatar>
+                </ListItemAvatar>
+                <ListItemText primary="Proposal ID" secondary={proposalId} />
+              </ListItem>
             </Grid>
-            <Grid item xs={5}>
-              <ListItemText primary="Proposal title" secondary={title} />
+            <Grid item xs={12} sm={4}>
+              <ListItem>
+                <ListItemAvatar>
+                  <Avatar>
+                    <DescriptionIcon />
+                  </Avatar>
+                </ListItemAvatar>
+                <ListItemText primary="Proposal title" secondary={title} />
+              </ListItem>
             </Grid>
-            <Grid item sm={1} xs={12}>
-              <ListItemAvatar>
-                <Avatar>
-                  <IdentifierIcon />
-                </Avatar>
-              </ListItemAvatar>
-            </Grid>
-            <Grid item xs={5}>
-              <ListItemText primary="Proposal ID" secondary={proposalId} />
-            </Grid>
-          </Grid>
-          <Divider variant="inset" className={classes.divider} />
-          <Grid container alignItems="center">
-            <Grid item sm={1} xs={12}>
-              <ListItemAvatar>
-                <Avatar>
-                  <Person />
-                </Avatar>
-              </ListItemAvatar>
-            </Grid>
-            <Grid item xs={5}>
-              <ListItemText
-                primary="Principal investigator"
-                secondary={getFullUserName(proposer)}
-              />
-            </Grid>
-            <Grid item sm={1} xs={12}>
-              <ListItemAvatar>
-                <Avatar>
-                  <ScienceIcon />
-                </Avatar>
-              </ListItemAvatar>
-            </Grid>
-            <Grid item xs={5}>
-              <ListItemText primary="Instrument" secondary={instrument?.name} />
+            <Grid item xs={12} sm={4}>
+              <ListItem>
+                <ListItemAvatar>
+                  <Avatar>
+                    <Person />
+                  </Avatar>
+                </ListItemAvatar>
+                <ListItemText
+                  primary="Principal investigator"
+                  secondary={getFullUserName(proposer)}
+                />
+              </ListItem>
             </Grid>
           </Grid>
           <Divider variant="inset" className={classes.divider} />
           <Grid container alignItems="center">
-            <Grid item sm={1} xs={12}>
-              <ListItemAvatar>
-                <Avatar>
-                  <HourglassEmptyIcon />
-                </Avatar>
-              </ListItemAvatar>
+            <Grid item sm={4} xs={12}>
+              <ListItem>
+                <ListItemAvatar>
+                  <Avatar>
+                    <ScienceIcon />
+                  </Avatar>
+                </ListItemAvatar>
+                <ListItemText
+                  primary="Instrument"
+                  secondary={instrument?.name}
+                />
+              </ListItem>
             </Grid>
-            <Grid item xs={5}>
-              <ListItemText
-                primary="Allocated time"
-                secondary={formatDuration(allocated)}
-                className={classes.flexColumn}
-              />
+            <Grid item sm={4} xs={12}>
+              <ListItem>
+                <ListItemAvatar>
+                  <Avatar>
+                    <HourglassFullIcon />
+                  </Avatar>
+                </ListItemAvatar>
+                <ListItemText
+                  primary="Allocated time"
+                  secondary={formatDuration(allocated)}
+                  className={classes.flexColumn}
+                />
+              </ListItem>
             </Grid>
-            <Grid item xs={6}>
-              <ListItemText
-                primary="Allocatable time"
-                className={classes.flexColumn}
-                secondary={
-                  <>
-                    <span
-                      className={clsx({
-                        [classes.allocatablePositive]: allocatable > 0,
-                        [classes.allocatableNegative]: allocatable < 0,
-                      })}
-                    >
-                      {allocatable < 0
-                        ? `0 seconds (+${formatDuration(allocatable)})`
-                        : formatDuration(allocatable)}
-                    </span>
-                  </>
-                }
-              />
+            <Grid item sm={4} xs={12}>
+              <ListItem>
+                <ListItemAvatar>
+                  <Avatar>
+                    <HourglassEmptyIcon />
+                  </Avatar>
+                </ListItemAvatar>
+                <ListItemText
+                  primary="Allocatable time"
+                  className={classes.flexColumn}
+                  secondary={
+                    <>
+                      <span
+                        className={clsx({
+                          [classes.allocatablePositive]: allocatable > 0,
+                          [classes.allocatableNegative]: allocatable < 0,
+                        })}
+                      >
+                        {allocatable < 0
+                          ? `0 seconds (+${formatDuration(allocatable)})`
+                          : formatDuration(allocatable)}
+                      </span>
+                    </>
+                  }
+                />
+              </ListItem>
             </Grid>
           </Grid>
         </Grid>
-        <Grid item sm={6}>
-          <Typography variant="h6" component="h6" align="left">
+        <Grid item sm={12}>
+          <Typography variant="h6" component="h3" align="left">
             Cycle information
           </Typography>
           <Grid container alignItems="center">
-            <Grid item sm={1} xs={12}>
-              <ListItemAvatar>
-                <Avatar>
-                  <CommentIcon />
-                </Avatar>
-              </ListItemAvatar>
+            <Grid item sm={4} xs={12}>
+              <ListItem>
+                <ListItemAvatar>
+                  <Avatar>
+                    <CommentIcon />
+                  </Avatar>
+                </ListItemAvatar>
+                <ListItemText
+                  primary="Call short code"
+                  secondary={callShortCode}
+                />
+              </ListItem>
             </Grid>
-            <Grid item xs={5}>
-              <ListItemText
-                primary="Call short code"
-                secondary={callShortCode}
-              />
+            <Grid item sm={4} xs={12}>
+              <ListItem>
+                <ListItemAvatar>
+                  <Avatar>
+                    <EventAvailableIcon />
+                  </Avatar>
+                </ListItemAvatar>
+                <ListItemText
+                  primary="Cycle starts"
+                  secondary={toTzLessDateTime(startCycle)}
+                />
+              </ListItem>
             </Grid>
-            <Grid item xs={6}>
-              <ListItemText primary="Cycle comment" secondary={cycleComment} />
-            </Grid>
-          </Grid>
-          <Divider variant="inset" className={classes.divider} />
-          <Grid container alignItems="center">
-            <Grid item sm={1} xs={12}>
-              <ListItemAvatar>
-                <Avatar>
-                  <CalendarTodayIcon />
-                </Avatar>
-              </ListItemAvatar>
-            </Grid>
-            <Grid item xs={5}>
-              <ListItemText
-                primary="Cycle starts"
-                secondary={toTzLessDateTime(startCycle)}
-              />
-            </Grid>
-            <Grid item xs={6}>
-              <ListItemText
-                primary="Cycle ends"
-                secondary={toTzLessDateTime(endCycle)}
-              />
+            <Grid item sm={4} xs={12}>
+              <ListItem>
+                <ListItemAvatar>
+                  <Avatar>
+                    <EventBusyIcon />
+                  </Avatar>
+                </ListItemAvatar>
+                <ListItemText
+                  primary="Cycle ends"
+                  secondary={toTzLessDateTime(endCycle)}
+                />
+              </ListItem>
             </Grid>
           </Grid>
         </Grid>
       </Grid>
 
-      <ButtonContainer className={classes.timeSlotsToolbar}>
-        <Typography
-          variant="h6"
-          component="h6"
-          align="left"
-          className={classes.timeSlotsTitle}
-        >
-          Time slots
-        </Typography>
-        {!isStepReadOnly && (
-          <Button
-            variant="contained"
-            color="primary"
-            component="span"
-            onClick={handleAdd}
-            data-cy="add-new-timeslot"
-            startIcon={
-              isAddingNewTimeSlot ? (
-                <CircularProgress size={20} color="inherit" />
-              ) : (
-                <AddIcon />
-              )
-            }
-            disabled={isAddingNewTimeSlot}
-          >
-            Add time slot
-          </Button>
-        )}
-      </ButtonContainer>
+      <Typography
+        variant="h6"
+        component="h3"
+        align="left"
+        className={classes.timeSlotsTitle}
+      >
+        Experiment time
+      </Typography>
 
-      {hasTimeSlots && (
-        <SimpleTabs
-          tab={selectedTab}
-          tabNames={scheduledEvents.map(
-            (item) => `${item.startsAt} - ${item.endsAt}`
-          )}
-        >
-          {scheduledEvents.map((event) => {
-            return (
-              <TimeSlotBooking
-                key={event.id}
-                onDelete={handleDelete}
-                activeScheduledEvent={event}
-                proposalBooking={proposalBooking}
-                setProposalBooking={setProposalBooking}
-              />
-            );
-          })}
-        </SimpleTabs>
-      )}
-      {!hasTimeSlots && (
-        <Paper elevation={3}>
-          <Box padding={2} textAlign="center">
-            No records to display. Start by adding new time slot
-          </Box>
-        </Paper>
-      )}
+      <SimpleTabs
+        tab={selectedTab}
+        tabNames={scheduledEvents.map(
+          (item) => `${item.startsAt} - ${item.endsAt}`
+        )}
+        orientation="vertical"
+        handleAdd={!isProposalBookingCompleted ? handleAdd : undefined}
+        noItemsText="No records to display. Start by adding new experiment time"
+      >
+        {scheduledEvents.map((event) => {
+          return (
+            <TimeSlotBooking
+              key={event.id}
+              onDelete={handleDelete}
+              activeScheduledEvent={event}
+              proposalBooking={proposalBooking}
+              setProposalBooking={setProposalBooking}
+            />
+          );
+        })}
+      </SimpleTabs>
 
       {hasEventOutsideCallCycleInterval && (
         <Alert

--- a/src/components/proposalBooking/ProposalDetailsAndBookingEvents.tsx
+++ b/src/components/proposalBooking/ProposalDetailsAndBookingEvents.tsx
@@ -268,6 +268,8 @@ export default function ProposalDetailsAndBookingEvents({
       enqueueSnackbar(getTranslation(error as ResourceId), {
         variant: 'error',
       });
+
+      throw error;
     } else {
       enqueueSnackbar('Time slot deleted successfully', {
         variant: 'success',
@@ -277,13 +279,11 @@ export default function ProposalDetailsAndBookingEvents({
         (scheduledEvent) => event.id !== scheduledEvent.id
       );
 
-      setSelectedTab(newEvents.length - 1);
+      setSelectedTab(newEvents.length ? newEvents.length - 1 : 0);
 
       setProposalBooking({ ...proposalBooking, scheduledEvents: newEvents });
     }
   };
-
-  const hasTimeSlots = !!scheduledEvents.length;
 
   return (
     <div className={classes.root}>

--- a/src/components/timeSlotBooking/TimeSlotBooking.tsx
+++ b/src/components/timeSlotBooking/TimeSlotBooking.tsx
@@ -377,8 +377,11 @@ export default function TimeSlotBooking({
       ),
       cb: async () => {
         setIsLoading(true);
-        await onDelete(activeScheduledEvent);
-        setIsLoading(false);
+        try {
+          await onDelete(activeScheduledEvent);
+        } catch {
+          setIsLoading(false);
+        }
       },
     });
   };

--- a/src/components/timeSlotBooking/TimeSlotDetails.tsx
+++ b/src/components/timeSlotBooking/TimeSlotDetails.tsx
@@ -9,6 +9,7 @@ import {
   ListItemAvatar,
   ListItemText,
   makeStyles,
+  Typography,
 } from '@material-ui/core';
 import {
   CalendarToday as CalendarTodayIcon,
@@ -185,6 +186,9 @@ export default function TimeSlotDetails({
 
   return (
     <>
+      <Typography variant="h6" component="h4" align="left">
+        Experiment information
+      </Typography>
       {isStepReadOnly && (
         <Alert severity="info">
           Time slot booking is already completed, you can not edit it.

--- a/src/components/timeSlotBooking/TimeSlotEquipmentBookingTable.tsx
+++ b/src/components/timeSlotBooking/TimeSlotEquipmentBookingTable.tsx
@@ -1,5 +1,5 @@
 import MaterialTable, { Column } from '@material-table/core';
-import { Button, makeStyles } from '@material-ui/core';
+import { Button, makeStyles, Typography } from '@material-ui/core';
 import { Add as AddIcon } from '@material-ui/icons';
 import Alert from '@material-ui/lab/Alert';
 import AlertTitle from '@material-ui/lab/AlertTitle';
@@ -162,7 +162,11 @@ export default function TimeSlotEquipmentBookingTable({
       )}
       <MaterialTable
         icons={tableIcons}
-        title="Time slot equipments"
+        title={
+          <Typography component="h4" variant="h6">
+            Equipments
+          </Typography>
+        }
         isLoading={loadingEquipments}
         columns={columns}
         data={equipments}
@@ -181,7 +185,7 @@ export default function TimeSlotEquipmentBookingTable({
           {
             icon: () => (
               <Button
-                variant="contained"
+                variant="outlined"
                 color="primary"
                 component="span"
                 data-cy="btn-book-equipment"
@@ -195,7 +199,7 @@ export default function TimeSlotEquipmentBookingTable({
             onClick: () => setEquipmentDialog(true),
             isFreeAction: true,
             hidden: isStepReadOnly,
-            tooltip: !equipmentDialog ? 'Book equipment' : '',
+            tooltip: !equipmentDialog ? 'Book experiment equipment' : '',
           },
         ]}
       />

--- a/src/components/timeSlotBooking/TimeSlotLostTimeTable.tsx
+++ b/src/components/timeSlotBooking/TimeSlotLostTimeTable.tsx
@@ -4,7 +4,12 @@ import MaterialTable, {
   Column,
   EditComponentProps,
 } from '@material-table/core';
-import { Button, CircularProgress, makeStyles } from '@material-ui/core';
+import {
+  Button,
+  CircularProgress,
+  makeStyles,
+  Typography,
+} from '@material-ui/core';
 import { Add as AddIcon } from '@material-ui/icons';
 import {
   KeyboardDateTimePicker,
@@ -246,7 +251,11 @@ function TimeSlotLostTimeTable({
     <div className={classes.root} data-cy="time-slot-lost-times-table">
       <MaterialTable
         icons={tableIcons}
-        title="Lost times"
+        title={
+          <Typography component="h4" variant="h6">
+            Lost times
+          </Typography>
+        }
         isLoading={loading || isLoading}
         columns={columns}
         data={lostTimes}
@@ -267,7 +276,7 @@ function TimeSlotLostTimeTable({
           {
             icon: () => (
               <Button
-                variant="contained"
+                variant="outlined"
                 color="primary"
                 component="span"
                 data-cy="btn-add-lost-time"
@@ -287,7 +296,7 @@ function TimeSlotLostTimeTable({
             hidden: isStepReadOnly,
             onClick: handleAdd,
             isFreeAction: true,
-            tooltip: 'Add lost time',
+            tooltip: 'Add experiment lost time',
           },
         ]}
       />

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,15 @@
 .MuiPaper-elevation2.MuiPaper-root {
   box-shadow: none;
 }
+
+.tinyScroll::-webkit-scrollbar {
+  -webkit-appearance: none;
+  max-height: 10px;
+  max-width: 10px;
+}
+
+.tinyScroll::-webkit-scrollbar-thumb {
+  border: 2px solid white;
+  border-radius: 4px;
+  background-color: rgba(0, 0, 0, 0.3);
+}


### PR DESCRIPTION
## Description

Now the proposal booking modal with experiment times is refactored to be more compatible and easier to use.

- Top proposal booking and cycle information is now grouped by topics
- We use vertical tabs for experiment times representation to optimize some space
- It is optimized for mobile as well at least to be able to see everything and use the booking functionality.
- Simple tabs component is reusable for vertical and horizontal tabs depending on a situation needed. 
- Buttons like `Book equipment` and some others that are not so important are now just outlined and not that highlighted for better user experience.

## Motivation and Context

Previously the modal was a bit confusing and now I think it is a lot more easier and clear to use.

## How Has This Been Tested

- e2e tests
- manual tests

## Fixes

https://jira.esss.lu.se/browse/SWAP-2079

## Changes

https://user-images.githubusercontent.com/6333063/148944058-44df6fa3-f37b-4899-aaaf-ec64a7197e49.mp4

## Depends on

https://github.com/UserOfficeProject/user-office-scheduler-backend/pull/119

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
