### PR TITLE
Pin Faker version to 5.5.3

### DIFF
--- a/cypress/package-lock.json
+++ b/cypress/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "cypress-real-events": "^1.6.0",
         "dotenv": "^8.6.0",
-        "faker": "^5.5.3",
+        "faker": "5.5.3",
         "graphql": "^16.1.0",
         "graphql-request": "^3.7.0",
         "graphql-tag": "2.12.6",

--- a/cypress/package.json
+++ b/cypress/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "cypress-real-events": "^1.6.0",
     "dotenv": "^8.6.0",
-    "faker": "^5.5.3",
+    "faker": "5.5.3",
     "graphql": "^16.1.0",
     "graphql-request": "^3.7.0",
     "graphql-tag": "2.12.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "eslint-plugin-react": "^7.27.1",
         "eslint-plugin-react-hooks": "^4.3.0",
         "eslint-plugin-unused-imports": "^2.0.0",
-        "faker": "^5.5.3",
+        "faker": "5.5.3",
         "http-proxy-middleware": "^2.0.1",
         "husky": "^4.3.8",
         "lint-staged": "^10.5.4",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "eslint-plugin-react": "^7.27.1",
     "eslint-plugin-react-hooks": "^4.3.0",
     "eslint-plugin-unused-imports": "^2.0.0",
-    "faker": "^5.5.3",
+    "faker": "5.5.3",
     "http-proxy-middleware": "^2.0.1",
     "husky": "^4.3.8",
     "lint-staged": "^10.5.4",


### PR DESCRIPTION
Part of UserOfficeProject/stfc-user-office-project#312

## Description
This prevents us from picking up any future updates, now that the package has been compromised. 

NPM packages are immutable once uploaded, so as long as the faker package isn't completely deleted we should be safe.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
