### PR TITLE
SWAP-2146-select-multiple-instruments-in-all-views

### DIFF
--- a/cypress/integration/calendar.spec.ts
+++ b/cypress/integration/calendar.spec.ts
@@ -323,6 +323,64 @@ context('Calendar tests', () => {
       cy.contains(/You have to select an instrument/i);
     });
 
+    it('should be able to select multiple instruments and select instrument on event creation', () => {
+      cy.initializeSession('UserOfficer');
+      cy.visit({
+        url: '/calendar',
+        timeout: 15000,
+      });
+
+      const newScheduledEvent = {
+        instrumentId: 1,
+        bookingType: ScheduledEventBookingType.MAINTENANCE,
+        startsAt: defaultEventBookingHourDateTime,
+        endsAt: getHourDateTimeAfter(1),
+        description: 'Test maintenance event on instrument 1',
+      };
+      cy.createEvent({ input: newScheduledEvent });
+      const newScheduledEvent2 = {
+        instrumentId: 3,
+        bookingType: ScheduledEventBookingType.SHUTDOWN,
+        startsAt: getHourDateTimeAfter(2),
+        endsAt: getHourDateTimeAfter(3),
+        description: 'Test maintenance event on instrument 3',
+      };
+      cy.createEvent({ input: newScheduledEvent2 });
+      cy.finishedLoading();
+
+      cy.get('[data-cy=input-instrument-select]').click();
+      cy.get('[aria-labelledby=input-instrument-select-label] [role=option]')
+        .first()
+        .click();
+
+      cy.finishedLoading();
+
+      cy.get('[data-cy=input-instrument-select] input').click();
+      cy.get('[aria-labelledby=input-instrument-select-label] [role=option]')
+        .last()
+        .click();
+
+      cy.finishedLoading();
+
+      cy.get('[data-cy=input-instrument-select]').should('contain.text', '+1');
+
+      const slot = new Date(defaultEventBookingHourDateTime).toISOString();
+      cy.get(`.rbc-day-slot [data-cy='event-slot-${slot}']`).should('exist');
+      const slot1 = new Date(getHourDateTimeAfter(2)).toISOString();
+      cy.get(`.rbc-day-slot [data-cy='event-slot-${slot1}']`).should('exist');
+
+      cy.get('[data-cy="btn-new-event"]').click();
+
+      cy.get('[data-cy="instrument"]')
+        .should('exist')
+        .find('input')
+        .should('not.be.disabled');
+
+      cy.get('[data-cy="instrument"]').click();
+
+      cy.get('#menu-instrument ul li').should('have.length', '3');
+    });
+
     it('should create a new event with right input', () => {
       cy.finishedLoading();
       cy.get('[data-cy=input-instrument-select]').click();

--- a/cypress/integration/proposal-booking.spec.ts
+++ b/cypress/integration/proposal-booking.spec.ts
@@ -313,7 +313,7 @@ context('Proposal booking tests ', () => {
           'not.exist'
         );
         cy.contains(
-          'Some of the time slots are booked outside call cycle start and end date'
+          'Some of the experiment times are booked outside of the call cycle start and end date'
         ).should('not.exist');
 
         cy.finishedLoading();
@@ -323,7 +323,7 @@ context('Proposal booking tests ', () => {
           'not.exist'
         );
         cy.contains(
-          'Time slot should be booked between call cycle start and end date'
+          'Experiment time should be booked between call cycle start and end date'
         ).should('not.exist');
 
         cy.get('[data-cy="startsAtInfo"]').click();
@@ -344,7 +344,7 @@ context('Proposal booking tests ', () => {
         );
         cy.get('[data-cy="event-outside-cycle-interval-warning"]').should(
           'contain.text',
-          'Time slot should be booked between call cycle start and end date'
+          'Experiment time should be booked between call cycle start and end date'
         );
 
         cy.get('[data-cy="btn-save"]').click();
@@ -354,8 +354,9 @@ context('Proposal booking tests ', () => {
           'exist'
         );
         cy.get('[data-cy="some-event-outside-cycle-interval-warning"]').should(
-          'contain.text',
-          'Some of the time slots are booked outside call cycle start and end date'
+          'have.attr',
+          'title',
+          'Some of the experiment times are booked outside of the call cycle start and end date'
         );
       });
 

--- a/cypress/integration/proposal-booking.spec.ts
+++ b/cypress/integration/proposal-booking.spec.ts
@@ -353,11 +353,11 @@ context('Proposal booking tests ', () => {
         cy.get('[data-cy="some-event-outside-cycle-interval-warning"]').should(
           'exist'
         );
-        cy.get('[data-cy="some-event-outside-cycle-interval-warning"]').should(
-          'have.attr',
-          'title',
-          'Some of the experiment times are booked outside of the call cycle start and end date.'
-        );
+        cy.get('[data-cy="some-event-outside-cycle-interval-warning"]')
+          .should('have.attr', 'title')
+          .then((title) => {
+            expect(title).not.to.be.empty;
+          });
       });
 
       it('should be able to add and edit local contact on the timeslot', () => {
@@ -1085,11 +1085,11 @@ context('Proposal booking tests ', () => {
         cy.contains(
           /Experiment time is already completed and it's not editable/i
         );
-        cy.get('[data-cy="proposal-booking-completed-info"]').should(
-          'have.attr',
-          'title',
-          /Proposal booking is already completed and it\'s not editable/i
-        );
+        cy.get('[data-cy="proposal-booking-completed-info"]')
+          .should('have.attr', 'title')
+          .then((title) => {
+            expect(title).not.to.be.empty;
+          });
       });
 
       it('Completed events should have gray color and opacity', () => {

--- a/cypress/integration/proposal-booking.spec.ts
+++ b/cypress/integration/proposal-booking.spec.ts
@@ -1083,10 +1083,12 @@ context('Proposal booking tests ', () => {
         cy.get('[data-cy="btn-ok"]').click();
 
         cy.contains(
-          /Time slot booking is already completed, you can not edit it/i
+          /Experiment time is already completed and it's not editable/i
         );
-        cy.contains(
-          /Proposal booking is already completed, you can not edit it/i
+        cy.get('[data-cy="proposal-booking-completed-info"]').should(
+          'have.attr',
+          'title',
+          /Proposal booking is already completed and it's not editable/i
         );
       });
 

--- a/cypress/integration/proposal-booking.spec.ts
+++ b/cypress/integration/proposal-booking.spec.ts
@@ -356,7 +356,7 @@ context('Proposal booking tests ', () => {
         cy.get('[data-cy="some-event-outside-cycle-interval-warning"]').should(
           'have.attr',
           'title',
-          'Some of the experiment times are booked outside of the call cycle start and end date'
+          'Some of the experiment times are booked outside of the call cycle start and end date.'
         );
       });
 
@@ -1088,7 +1088,7 @@ context('Proposal booking tests ', () => {
         cy.get('[data-cy="proposal-booking-completed-info"]').should(
           'have.attr',
           'title',
-          /Proposal booking is already completed and it's not editable/i
+          /Proposal booking is already completed and it\'s not editable/i
         );
       });
 

--- a/src/components/calendar/CalendarView.tsx
+++ b/src/components/calendar/CalendarView.tsx
@@ -166,7 +166,7 @@ const CalendarView: React.FC<CalendarViewProps> = ({
 
   return (
     <>
-      <Toolbar filter={filter} />
+      <Toolbar filter={filter} multipleInstruments />
       <DragAndDropCalendar
         popup
         selectable

--- a/src/components/calendar/CalendarViewContainer.tsx
+++ b/src/components/calendar/CalendarViewContainer.tsx
@@ -46,9 +46,11 @@ import {
   ScheduledEventBookingType,
   GetScheduledEventsQuery,
   ProposalBooking,
+  Maybe,
 } from 'generated/sdk';
 import { useDataApi } from 'hooks/common/useDataApi';
 import { useQuery } from 'hooks/common/useQuery';
+import { PartialInstrument } from 'hooks/instrument/useUserInstruments';
 import useInstrumentProposalBookings from 'hooks/proposalBooking/useInstrumentProposalBookings';
 import useEquipmentScheduledEvents from 'hooks/scheduledEvent/useEquipmentScheduledEvents';
 import useScheduledEvents from 'hooks/scheduledEvent/useScheduledEvents';
@@ -212,10 +214,10 @@ export default function CalendarViewContainer() {
     (querySchedulerView as SchedulerViews) || SchedulerViews.CALENDAR
   );
   const [selectedEvent, setSelectedEvent] = useState<
-    | Pick<
+    | (Pick<
         ScheduledEvent,
         'id' | 'bookingType' | 'startsAt' | 'endsAt' | 'description'
-      >
+      > & { instrument: Maybe<PartialInstrument> })
     | SlotInfo
     | null
   >(null);
@@ -654,9 +656,7 @@ export default function CalendarViewContainer() {
             {queryInstrument && (
               <ScheduledEventDialog
                 selectedEvent={selectedEvent}
-                selectedInstrumentId={
-                  getArrayOfIdsFromQuery(queryInstrument)[0] || 0
-                }
+                selectedInstrumentIds={getArrayOfIdsFromQuery(queryInstrument)}
                 isDialogOpen={selectedEvent !== null}
                 closeDialog={closeDialog}
               />

--- a/src/components/calendar/CalendarViewContainer.tsx
+++ b/src/components/calendar/CalendarViewContainer.tsx
@@ -265,20 +265,6 @@ export default function CalendarViewContainer() {
     }
   }, [querySchedulerView]);
 
-  useEffect(() => {
-    if (
-      schedulerActiveView === SchedulerViews.CALENDAR ||
-      schedulerActiveView === SchedulerViews.TABLE
-    ) {
-      const queryInstrumentIds = getArrayOfIdsFromQuery(queryInstrument);
-      // NOTE: If table or calendar view set the selected instrument to first one if multiple are selected in timeline view.
-      if (queryInstrumentIds && queryInstrumentIds.length > 1) {
-        query.set('instrument', `${queryInstrumentIds[0]}`);
-        history.push(`?${query}`);
-      }
-    }
-  }, [schedulerActiveView, history, query, queryInstrument]);
-
   const {
     proposalBookings,
     loading: loadingBookings,

--- a/src/components/calendar/TableView.tsx
+++ b/src/components/calendar/TableView.tsx
@@ -55,6 +55,7 @@ const TableView: React.FC<TableViewProps> = ({
         filter={filter}
         shouldIncludeCalendarNavigation
         shouldIncludeLabelText
+        multipleInstruments
       />
       <MaterialTable
         icons={tableIcons}

--- a/src/components/proposalBooking/ProposalDetailsAndBookingEvents.tsx
+++ b/src/components/proposalBooking/ProposalDetailsAndBookingEvents.tsx
@@ -298,7 +298,7 @@ export default function ProposalDetailsAndBookingEvents({
             {isProposalBookingCompleted && (
               <Tooltip
                 data-cy="proposal-booking-completed-info"
-                title="Proposal booking is already completed and it's not editable."
+                title="Proposal booking is already completed and it's not editable"
               >
                 <Info style={{ color: theme.palette.info.main }} />
               </Tooltip>

--- a/src/components/proposalBooking/ProposalDetailsAndBookingEvents.tsx
+++ b/src/components/proposalBooking/ProposalDetailsAndBookingEvents.tsx
@@ -7,6 +7,8 @@ import {
   ListItemAvatar,
   ListItemText,
   makeStyles,
+  useTheme,
+  Tooltip,
   Typography,
 } from '@material-ui/core';
 import {
@@ -17,8 +19,9 @@ import {
   HourglassEmpty as HourglassEmptyIcon,
   Description as DescriptionIcon,
   Person,
+  WarningOutlined,
 } from '@material-ui/icons';
-import { Alert, AlertTitle } from '@material-ui/lab';
+import { Alert } from '@material-ui/lab';
 import clsx from 'clsx';
 import humanizeDuration from 'humanize-duration';
 import moment from 'moment';
@@ -138,6 +141,7 @@ export default function ProposalDetailsAndBookingEvents({
   } = proposalBooking;
 
   const classes = useStyles();
+  const theme = useTheme();
 
   const { scheduledEvents } = proposalBooking;
 
@@ -445,7 +449,16 @@ export default function ProposalDetailsAndBookingEvents({
         align="left"
         className={classes.timeSlotsTitle}
       >
-        Experiment time
+        Experiment time{' '}
+        {hasEventOutsideCallCycleInterval && (
+          <Tooltip
+            title="Some of the experiment times are booked outside of the call cycle start and end
+          date."
+            data-cy="some-event-outside-cycle-interval-warning"
+          >
+            <WarningOutlined style={{ color: theme.palette.warning.main }} />
+          </Tooltip>
+        )}
       </Typography>
 
       <SimpleTabs
@@ -469,18 +482,6 @@ export default function ProposalDetailsAndBookingEvents({
           );
         })}
       </SimpleTabs>
-
-      {hasEventOutsideCallCycleInterval && (
-        <Alert
-          severity="warning"
-          className={classes.spacingTop}
-          data-cy="some-event-outside-cycle-interval-warning"
-        >
-          <AlertTitle>Warning</AlertTitle>
-          Some of the time slots are booked outside call cycle start and end
-          date.
-        </Alert>
-      )}
     </div>
   );
 }

--- a/src/components/proposalBooking/ProposalDetailsAndBookingEvents.tsx
+++ b/src/components/proposalBooking/ProposalDetailsAndBookingEvents.tsx
@@ -20,8 +20,8 @@ import {
   Description as DescriptionIcon,
   Person,
   WarningOutlined,
+  Info,
 } from '@material-ui/icons';
-import { Alert } from '@material-ui/lab';
 import clsx from 'clsx';
 import humanizeDuration from 'humanize-duration';
 import moment from 'moment';
@@ -291,16 +291,18 @@ export default function ProposalDetailsAndBookingEvents({
 
   return (
     <div className={classes.root}>
-      {isProposalBookingCompleted && (
-        <Alert severity="info">
-          Proposal booking is already completed, you can not edit it.
-        </Alert>
-      )}
-
       <Grid container spacing={2}>
         <Grid item sm={12}>
           <Typography variant="h6" component="h3" align="left">
-            Proposal information
+            Proposal information{' '}
+            {isProposalBookingCompleted && (
+              <Tooltip
+                data-cy="proposal-booking-completed-info"
+                title="Proposal booking is already completed and it's not editable."
+              >
+                <Info style={{ color: theme.palette.info.main }} />
+              </Tooltip>
+            )}
           </Typography>
           <Grid container alignItems="center">
             <Grid item xs={12} sm={4}>

--- a/src/components/scheduledEvent/ScheduledEventForm.tsx
+++ b/src/components/scheduledEvent/ScheduledEventForm.tsx
@@ -1,5 +1,5 @@
 import MomentUtils from '@date-io/moment';
-import { MenuItem } from '@material-ui/core';
+import { MenuItem, TextField as MuiTextField } from '@material-ui/core';
 import { MuiPickersUtilsProvider } from '@material-ui/pickers';
 import { Field } from 'formik';
 import { TextField } from 'formik-material-ui';
@@ -10,6 +10,7 @@ import {
   ProposalBookingStatusCore,
   ScheduledEventBookingType,
 } from 'generated/sdk';
+import useUserInstruments from 'hooks/instrument/useUserInstruments';
 import { TZ_LESS_DATE_TIME_FORMAT } from 'utils/date';
 
 export type BookingTypes = typeof ScheduledEventBookingType;
@@ -42,9 +43,49 @@ export const ScheduledEventStatusMap: Record<
 };
 
 export default function ScheduledEventForm() {
+  const { instruments, loading } = useUserInstruments();
+
+  /**
+   * Looks like if the items for a select are updated
+   * after the  select field was mounted
+   * you will get warning about out of range values.
+   * To fix that just avoid mounting the real select until it's loaded
+   */
+  const instrumentSelection = loading ? (
+    <MuiTextField
+      label="Instrument"
+      defaultValue="Loading..."
+      disabled
+      margin="normal"
+      InputLabelProps={{
+        shrink: true,
+      }}
+      fullWidth
+      required
+    />
+  ) : (
+    <Field
+      component={TextField}
+      select
+      required
+      name="instrument"
+      label="Instrument"
+      margin="normal"
+      fullWidth
+      data-cy="instrument"
+    >
+      {instruments.map((instrument) => (
+        <MenuItem key={instrument.id} value={instrument.id}>
+          {instrument.name}
+        </MenuItem>
+      ))}
+    </Field>
+  );
+
   return (
     <>
       <MuiPickersUtilsProvider utils={MomentUtils}>
+        {instrumentSelection}
         <Field
           component={KeyboardDateTimePicker}
           required
@@ -85,12 +126,6 @@ export default function ScheduledEventForm() {
         </MenuItem>
         <MenuItem value={ScheduledEventBookingType.SHUTDOWN}>
           {BookingTypesMap[ScheduledEventBookingType.SHUTDOWN]}
-        </MenuItem>
-        <MenuItem value={ScheduledEventBookingType.COMMISSIONING} disabled>
-          {BookingTypesMap[ScheduledEventBookingType.COMMISSIONING]}
-        </MenuItem>
-        <MenuItem value={ScheduledEventBookingType.USER_OPERATIONS} disabled>
-          {BookingTypesMap[ScheduledEventBookingType.USER_OPERATIONS]}
         </MenuItem>
       </Field>
       <Field

--- a/src/components/timeSlotBooking/TimeSlotDetails.tsx
+++ b/src/components/timeSlotBooking/TimeSlotDetails.tsx
@@ -191,7 +191,7 @@ export default function TimeSlotDetails({
       </Typography>
       {isStepReadOnly && (
         <Alert severity="info">
-          Experiment time is already completed and it&apos;s not editable.
+          Experiment time is already completed and it&apos;s not editable
         </Alert>
       )}
       <PeopleModal

--- a/src/components/timeSlotBooking/TimeSlotDetails.tsx
+++ b/src/components/timeSlotBooking/TimeSlotDetails.tsx
@@ -191,7 +191,7 @@ export default function TimeSlotDetails({
       </Typography>
       {isStepReadOnly && (
         <Alert severity="info">
-          Time slot booking is already completed, you can not edit it.
+          Experiment time is already completed and it&apos;s not editable.
         </Alert>
       )}
       <PeopleModal

--- a/src/components/timeSlotBooking/TimeSlotDetails.tsx
+++ b/src/components/timeSlotBooking/TimeSlotDetails.tsx
@@ -205,6 +205,17 @@ export default function TimeSlotDetails({
         userRole={UserRole.INSTRUMENT_SCIENTIST}
         data={localContactOptions}
       />
+      {isOutsideCallCycleInterval && (
+        <Alert
+          severity="warning"
+          className={classes.spacingTop}
+          data-cy="event-outside-cycle-interval-warning"
+        >
+          <AlertTitle>Warning</AlertTitle>
+          Experiment time should be booked between call cycle start and end
+          date.
+        </Alert>
+      )}
       <Grid container spacing={2}>
         <MuiPickersUtilsProvider utils={MomentUtils}>
           <Grid item sm={6} xs={12}>
@@ -426,16 +437,6 @@ export default function TimeSlotDetails({
           </Grid>
         </MuiPickersUtilsProvider>
       </Grid>
-      {isOutsideCallCycleInterval && (
-        <Alert
-          severity="warning"
-          className={classes.spacingTop}
-          data-cy="event-outside-cycle-interval-warning"
-        >
-          <AlertTitle>Warning</AlertTitle>
-          Time slot should be booked between call cycle start and end date.
-        </Alert>
-      )}
     </>
   );
 }


### PR DESCRIPTION
## Description

- Allow multiple instrument selection in all views. Previously it was possible to select multiple instruments only in the timeline view.
- Also added support to select an instrument when you try to add new event of type `Maintenance` or `Shutdown` because previously it used the selected instrument from the main selection toolbar but now we can have multiple.

## Motivation and Context

`TODO`: Maybe there will be a need for instrument color because it is harder to see the difference when events from multiple instruments are shown in the calendar.

## How Has This Been Tested

- e2e tests
- manual tests

## Fixes

https://jira.esss.lu.se/browse/SWAP-2146

## Changes

https://user-images.githubusercontent.com/6333063/149167917-06cf81b9-5a3f-4bc2-9010-0a982d2801af.mp4

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
