### PR TITLE
refactor: remove unused commissioning event booking type

### DIFF
--- a/src/components/calendar/common/Event.tsx
+++ b/src/components/calendar/common/Event.tsx
@@ -65,12 +65,6 @@ export const getBookingTypeStyle = (
   const filter = `grayscale(${grayscale}) opacity(${opacity})`;
 
   switch (event.bookingType) {
-    case ScheduledEventBookingType.COMMISSIONING:
-      return {
-        background: 'rgb(147, 225, 216)',
-        color: '#000',
-        filter: filter,
-      };
     case ScheduledEventBookingType.MAINTENANCE:
       return {
         background: 'rgb(255, 166, 158)',

--- a/src/components/scheduledEvent/ScheduledEventForm.tsx
+++ b/src/components/scheduledEvent/ScheduledEventForm.tsx
@@ -16,7 +16,6 @@ import { TZ_LESS_DATE_TIME_FORMAT, TZ_LESS_DATE_TIME_MASK } from 'utils/date';
 export type BookingTypes = typeof ScheduledEventBookingType;
 
 export const BookingTypesMap: Record<keyof BookingTypes, string> = {
-  COMMISSIONING: 'Commissioning',
   MAINTENANCE: 'Maintenance',
   SHUTDOWN: 'Shutdown',
   USER_OPERATIONS: 'User operations',

--- a/src/generated/sdk.ts
+++ b/src/generated/sdk.ts
@@ -515,6 +515,7 @@ export type Feature = {
 
 export enum FeatureId {
   EMAIL_INVITE = 'EMAIL_INVITE',
+  EMAIL_SEARCH = 'EMAIL_SEARCH',
   EXTERNAL_AUTH = 'EXTERNAL_AUTH',
   RISK_ASSESSMENT = 'RISK_ASSESSMENT',
   SCHEDULER = 'SCHEDULER',
@@ -2995,7 +2996,6 @@ export type ScheduledEvent = {
 };
 
 export enum ScheduledEventBookingType {
-  COMMISSIONING = 'COMMISSIONING',
   EQUIPMENT = 'EQUIPMENT',
   MAINTENANCE = 'MAINTENANCE',
   SHUTDOWN = 'SHUTDOWN',


### PR DESCRIPTION
## Description

Removing booking type that is not used at all for now but was there from the beginning.
