### PR TITLE
chore: Add github auto release and tagging action and improve documentation

### DIFF
--- a/.github/workflows/github-tag-and-release.yml
+++ b/.github/workflows/github-tag-and-release.yml
@@ -1,0 +1,41 @@
+name: Bump version
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Bump version and push tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v5.5
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create a GitHub release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.tag_version.outputs.new_tag }}
+          release_name: Release ${{ steps.tag_version.outputs.new_tag }}
+          body: ${{ steps.tag_version.outputs.changelog }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+        # Build and push release image tagged with the same tag as github release
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          build-args: BUILD_VERSION=${{ github.sha }}
+          push: true
+          tags: dmsc/duo-scheduler-frontend:${{ steps.tag_version.outputs.new_tag }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,16 @@
 
 # testing
 /coverage
+/cypress/videos/
+/cypress/screenshots/
+/cypress/node_modules
 
 # production
 /build
+
+# Env files
+.env*
+!.env.example
 
 # misc
 .DS_Store
@@ -17,6 +24,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.vscode/*
 
 npm-debug.log*
 yarn-debug.log*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contribution guide
+
+## Developing UserOfficeProject/user-office-scheduler-frontend
+
+You consider contributing changes to UserOfficeProject/user-office-scheduler-frontend – thank you!
+Please consider these guidelines when filing a pull request:
+
+- Commits follow the [Angular commit convention](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines)
+- JavaScript is written using ES2015 features
+- 2 spaces indentation
+- Features and bug fixes should be covered by test cases
+
+## Creating releases
+
+UserOfficeProject/user-office-scheduler-frontend uses [semantic-release](https://github.com/semantic-release/semantic-release) to release new versions automatically.
+
+- Commits of type `fix` will trigger bugfix releases, think `0.0.1`
+- Commits of type `feat` will trigger feature releases, think `0.1.0`
+- Commits with `BREAKING CHANGE` in body or footer will trigger breaking releases, think `1.0.0`
+
+All other commit types will trigger no new release.
+
+> **_NOTE:_** When merging the pull requests with `Squash and merge` option on github, the title of the pull request should follow the commit guidelines mentioned above because all the commits are squashed into one commit with title od the PR as a message of the commit. Otherwise when using normal `Merge pull request` the title of the pull request doesn't need to follow the commit guidelines but only the commit messages.

--- a/README.md
+++ b/README.md
@@ -1,44 +1,24 @@
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
-
 ## Available Scripts
 
 In the project directory, you can run:
 
-### `npm start`
+### `npm run dev`
 
-Runs the app in the development mode.<br />
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+Runs the app in the development mode.<br>
+Open [http://localhost:3100](http://localhost:3100) to view it in the browser.
 
-The page will reload if you make edits.<br />
-You will also see any lint errors in the console.
+> **_NOTE:_** Scheduler is not meant to be used as standalone. It depends on [user-office-backend](https://github.com/UserOfficeProject/user-office-backend) and [user-office-scheduler-backend](https://github.com/UserOfficeProject/user-office-scheduler-backend). So to be able to run everything locally you need to have `user-office-backend` running then start the `user-office-scheduler-backend` and finally run [user-office-gateway](https://github.com/UserOfficeProject/user-office-gateway) as well which connects them both and exposes endpoint [http://localhost:4100](http://localhost:4100) where you can query data from both services.
 
-### `npm test`
+### `npm run lint`
 
-Launches the test runner in the interactive watch mode.<br />
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+Lints typescript code and log if there are any errors.<br>
+`npm run lint:fix` should be used if you want to fix all auto-fixable errors and warnings.
 
-### `npm run build`
+### `npm run generate:local`
 
-Builds the app for production to the `build` folder.<br />
-It correctly bundles React in production mode and optimizes the build for the best performance.
+Need to have `user-office-backend`, `user-office-scheduler-backend` and `user-office-gateway` running to run this command successfully.<br>
+It generates typescript `sdk.ts` file containing types from both `user-office-backend` and `user-office-scheduler-backend` that are shared and used in the `user-office-scheduler-frontend` code.
 
-The build is minified and the filenames include the hashes.<br />
-Your app is ready to be deployed!
+## Contribution and release versioning
 
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-### `npm run eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
-
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
-
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
+Please refer to the [Contribution guide](CONTRIBUTING.md) to get information about contributing and versioning.


### PR DESCRIPTION
## Description

This branch is created from master and it only adds the github action for auto release tagging generation. I first merge it to master and then plan to merge develop into master so it could automatically generate new release version number and notes for the first official release.

## Fixes

https://jira.esss.lu.se/browse/SWAP-2326

## Changes

Adding readme file content, contribution guides and github auto release and tagging action.

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [x] All relevant doc has been updated
