### PR TITLE
Fix equipment typo

### DIFF
--- a/src/components/equipment/Equipments.tsx
+++ b/src/components/equipment/Equipments.tsx
@@ -60,7 +60,7 @@ export default function Equipments() {
           <StyledPaper margin={[0, 1]} data-cy="role-selection-table">
             <MaterialTable
               icons={tableIcons}
-              title="Equipments"
+              title="Equipment"
               columns={columns}
               data={equipments}
               isLoading={loading}

--- a/src/components/timeSlotBooking/TimeSlotEquipmentBookingTable.tsx
+++ b/src/components/timeSlotBooking/TimeSlotEquipmentBookingTable.tsx
@@ -167,7 +167,7 @@ export default function TimeSlotEquipmentBookingTable({
         icons={tableIcons}
         title={
           <Typography component="h4" variant="h6">
-            Equipments
+            Equipment
           </Typography>
         }
         isLoading={loadingEquipments}


### PR DESCRIPTION
## Description

Quick typo fix for equipment. The noun equipment does not have a plural form. It is used in the singular only.