### PR TITLE
chore: update outdated GH actions

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -22,7 +22,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -16,7 +16,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2.5
+      - uses: actions/checkout@v2.5.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -16,7 +16,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -16,10 +16,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2.5.0
+      - uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1.7.0
+        uses: docker/setup-buildx-action@v1
 
       - name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -42,7 +42,7 @@ jobs:
           BRANCH_NAME=${GITHUB_REF#refs/heads/}
 
           # set output variable accessible in the action
-          echo ::set-output name=branch::${BRANCH_NAME}
+          echo "branch=${BRANCH_NAME}" >> $GITHUB_OUTPUT
 
       # For debugging capture the selected branch
       - name: Extracted branch

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2.5.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v1.7.0
 
       - name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/github-tag-and-release.yml
+++ b/.github/workflows/github-tag-and-release.yml
@@ -26,7 +26,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/github-tag-and-release.yml
+++ b/.github/workflows/github-tag-and-release.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.5.0
+      - uses: actions/checkout@v3
       - name: Bump version and push tag
         id: tag_version
         uses: mathieudutour/github-tag-action@v5.5
@@ -23,7 +23,7 @@ jobs:
           body: ${{ steps.tag_version.outputs.changelog }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1.7.0
+        uses: docker/setup-buildx-action@v1
 
       - name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/github-tag-and-release.yml
+++ b/.github/workflows/github-tag-and-release.yml
@@ -23,7 +23,7 @@ jobs:
           body: ${{ steps.tag_version.outputs.changelog }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/github-tag-and-release.yml
+++ b/.github/workflows/github-tag-and-release.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.5
       - name: Bump version and push tag
         id: tag_version
         uses: mathieudutour/github-tag-action@v5.5

--- a/.github/workflows/github-tag-and-release.yml
+++ b/.github/workflows/github-tag-and-release.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.5
+      - uses: actions/checkout@v2.5.0
       - name: Bump version and push tag
         id: tag_version
         uses: mathieudutour/github-tag-action@v5.5

--- a/.github/workflows/github-tag-and-release.yml
+++ b/.github/workflows/github-tag-and-release.yml
@@ -23,7 +23,7 @@ jobs:
           body: ${{ steps.tag_version.outputs.changelog }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v1.7.0
 
       - name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -14,7 +14,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.5
 
       - name: Cache app docker layers and image
         id: cached-image
@@ -45,7 +45,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.5
 
       - name: Login to GitHub Packages Docker Registry
         uses: docker/login-action@v1
@@ -74,7 +74,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.5
 
       - name: Login to GitHub Packages Docker Registry
         uses: docker/login-action@v1

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -14,7 +14,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v2.5
+      - uses: actions/checkout@v2.5.0
 
       - name: Cache app docker layers and image
         id: cached-image
@@ -45,7 +45,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v2.5
+      - uses: actions/checkout@v2.5.0
 
       - name: Login to GitHub Packages Docker Registry
         uses: docker/login-action@v1
@@ -74,7 +74,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v2.5
+      - uses: actions/checkout@v2.5.0
 
       - name: Login to GitHub Packages Docker Registry
         uses: docker/login-action@v1

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Login to GitHub Packages Docker Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: docker.pkg.github.com
           username: ${{ github.actor }}
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Login to GitHub Packages Docker Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: docker.pkg.github.com
           username: ${{ github.actor }}
@@ -264,7 +264,7 @@ jobs:
           docker load --input /tmp/.buildx-image-cache/img.tar
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -14,7 +14,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v2.5.0
+      - uses: actions/checkout@v3
 
       - name: Cache app docker layers and image
         id: cached-image
@@ -30,7 +30,7 @@ jobs:
 
       - name: Set up Docker Buildx
         if: steps.cached-image.outputs.cache-hit != 'true'
-        uses: docker/setup-buildx-action@v1.7.0
+        uses: docker/setup-buildx-action@v1
 
       - name: Build and cache image
         if: steps.cached-image.outputs.cache-hit != 'true'
@@ -45,7 +45,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v2.5.0
+      - uses: actions/checkout@v3
 
       - name: Login to GitHub Packages Docker Registry
         uses: docker/login-action@v1
@@ -74,7 +74,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v2.5.0
+      - uses: actions/checkout@v3
 
       - name: Login to GitHub Packages Docker Registry
         uses: docker/login-action@v1

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Set up Docker Buildx
         if: steps.cached-image.outputs.cache-hit != 'true'
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v1.7.0
 
       - name: Build and cache image
         if: steps.cached-image.outputs.cache-hit != 'true'

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Cache app docker layers and image
         id: cached-image
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             /tmp/.buildx-layer-cache
@@ -92,7 +92,7 @@ jobs:
 
       - name: Load app cache
         id: cached-image
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             /tmp/.buildx-layer-cache
@@ -242,7 +242,7 @@ jobs:
     steps:
       - name: Load app cache
         id: cached-image
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             /tmp/.buildx-layer-cache

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -149,7 +149,7 @@ jobs:
             https://registry.hub.docker.com/v1/repositories/dmsc/duo-gateway/tags \
             https://api.github.com/repos/UserOfficeProject/user-office-gateway/branches
           )
-          
+
           FACTORY_TAGS=$(check_feature ${{ github.head_ref }} \
             https://registry.hub.docker.com/v1/repositories/dmsc/duo-factory/tags \
             https://api.github.com/repos/UserOfficeProject/user-office-factory/branches
@@ -169,16 +169,16 @@ jobs:
           if [[ $GATEWAY_TAGS == "2" ]]; then
             GATEWAY_TAG="${{ github.head_ref }}"
           fi
-          
+
           FACTORY_TAG=develop
           if [[ $FACTORY_TAGS == "2" ]]; then
             FACTORY_TAG="${{ github.head_ref }}"
           fi
 
-          echo ::set-output name=SCHEDULER_BE_TAG::${SCHEDULER_BE_TAG}
-          echo ::set-output name=UO_BE_TAG::${UO_BE_TAG}
-          echo ::set-output name=GATEWAY_TAG::${GATEWAY_TAG}
-          echo ::set-output name=FACTORY_TAG::${FACTORY_TAG}
+          echo "SCHEDULER_BE_TAG=${SCHEDULER_BE_TAG}" >> $GITHUB_OUTPUT
+          echo "UO_BE_TAG=${UO_BE_TAG}" >> $GITHUB_OUTPUT
+          echo "GATEWAY_TAG=${GATEWAY_TAG}" >> $GITHUB_OUTPUT
+          echo "FACTORY_TAG=${FACTORY_TAG}" >> $GITHUB_OUTPUT
 
       - name: Download required repositories
         run: |
@@ -215,7 +215,7 @@ jobs:
           export USER_OFFICE_SCHEDULER_FRONTEND_DIR=$REPO_DIR_NAME
 
           export USER_OFFICE_GATEWAY_TAG=${{ steps.resolve_rep.outputs.GATEWAY_TAG }}
-          
+
           export USER_OFFICE_FACTORY_TAG=${{ steps.resolve_rep.outputs.FACTORY_TAG }}
           export USER_OFFICE_FACTORY_ENDPOINT=noop
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Set up Docker Buildx
         if: steps.cached-image.outputs.cache-hit != 'true'
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build and cache image
         if: steps.cached-image.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Description

This PR fixes the deprecation warning
![image](https://user-images.githubusercontent.com/58165815/199960146-8035d3a0-8f00-498a-bd36-9f45ab32434d.png)

Here is the list of updated actions
- actions/checkout@v2 -> actions/checkout@v3	
- setup-buildx-action@v1 -> setup-buildx-action@v2
- docker/login-action@v1 -> docker/login-action@v2
- actions/cache@v2 -> actions/cache@v3

## Motivation and Context

Failing to fix it, might suddenly break builds in the future

