### PR TITLE
chore: exclude pushing to dockerhub if dependabot is creating the PR

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -238,6 +238,8 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     needs: e2e
+    # Don't push the built image if dependabot is creating the PR
+    if: github.actor != 'dependabot[bot]'
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Load app cache

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -266,12 +266,16 @@ jobs:
           docker load --input /tmp/.buildx-image-cache/img.tar
 
       - name: Login to DockerHub
+        # Don't login if dependabot is creating the PR
+        if: ${{ !startsWith(github.head_ref, 'dependabot') }}
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Push
+        # Don't push the image if dependabot is creating the PR
+        if: ${{ !startsWith(github.head_ref, 'dependabot') }}
         run: |
           docker tag duo-scheduler-frontend:${{ github.sha }} dmsc/duo-scheduler-frontend:${{ github.head_ref }}
           docker push dmsc/duo-scheduler-frontend:${{ github.head_ref }}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -239,7 +239,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: e2e
     # Don't push the built image if dependabot is creating the PR
-    if: github.actor != 'dependabot[bot]'
+    if: ${{ github.actor == 'dependabot[bot]' }}
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Load app cache

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -239,7 +239,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: e2e
     # Don't push the built image if dependabot is creating the PR
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: github.actor != 'dependabot[bot]'
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Load app cache


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Update test-build action to exclude login and push to docker hub if dependabot is creating the PRs