### PR TITLE
Swap 3111

### DIFF
--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -133,7 +133,6 @@ export function UserContextProvider({ children }: UserContextProviderProps) {
         'redirect_uri',
         window.location.origin
       );
-      console.log(loginUrlWithRedirect);
       window.location.assign(loginUrlWithRedirect);
     } else {
       // if there is no logout url, just clear the user context

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -126,9 +126,15 @@ export function UserContextProvider({ children }: UserContextProviderProps) {
     const loginUrl = settings.get(
       SettingsId.EXTERNAL_AUTH_LOGIN_URL
     )?.settingsValue;
-    //clearSession();
+    localStorage.removeItem('token');
     if (loginUrl) {
-      window.location.assign(loginUrl);
+      const loginUrlWithRedirect = new URL(loginUrl);
+      loginUrlWithRedirect.searchParams.set(
+        'redirect_uri',
+        window.location.origin
+      );
+      console.log(loginUrlWithRedirect);
+      window.location.assign(loginUrlWithRedirect);
     } else {
       // if there is no logout url, just clear the user context
       dispatch({

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -32,6 +32,7 @@ export type UserContextData = {
   roles: Role[];
   handleNewToken: (token: string) => void;
   handleLogout: () => Promise<void>;
+  handleSessionExpired: () => Promise<void>;
 };
 
 const initialState = {
@@ -42,6 +43,9 @@ const initialState = {
   currentRole: null,
   handleNewToken: () => {},
   handleLogout: async () => {},
+  handleSessionExpired: async () => {
+    return;
+  },
 };
 
 export const UserContext = createContext<UserContextData>(initialState);
@@ -118,6 +122,22 @@ export function UserContextProvider({ children }: UserContextProviderProps) {
     }
   }, [api, settings]);
 
+  async function handleSessionExpired() {
+    const loginUrl = settings.get(
+      SettingsId.EXTERNAL_AUTH_LOGIN_URL
+    )?.settingsValue;
+    //clearSession();
+    if (loginUrl) {
+      window.location.assign(loginUrl);
+    } else {
+      // if there is no logout url, just clear the user context
+      dispatch({
+        type: UserActionType.SET_NOT_AUTHENTICATED,
+        payload: null,
+      });
+    }
+  }
+
   const handleNewToken = (token: string | null) => {
     let decodedToken = null;
     try {
@@ -150,6 +170,7 @@ export function UserContextProvider({ children }: UserContextProviderProps) {
         ...userState,
         handleNewToken,
         handleLogout,
+        handleSessionExpired,
       }}
     >
       {userState.stateInitialized ? children : <Loader />}

--- a/src/hooks/common/useDataApi.ts
+++ b/src/hooks/common/useDataApi.ts
@@ -225,7 +225,8 @@ class AuthorizedGraphQLClient extends GraphQLClient {
 }
 
 export function useDataApi() {
-  const { token, handleNewToken, handleLogout } = useContext(UserContext);
+  const { token, handleNewToken, handleSessionExpired } =
+    useContext(UserContext);
   const settingsContext = useContext(SettingsContext);
   const externalAuthLoginUrl = settingsContext.settings.get(
     SettingsId.EXTERNAL_AUTH_LOGIN_URL
@@ -241,14 +242,20 @@ export function useDataApi() {
               token,
               enqueueSnackbar,
               () => {
-                handleLogout();
+                handleSessionExpired();
               },
               handleNewToken,
               externalAuthLoginUrl ? externalAuthLoginUrl : undefined
             )
           : new GraphQLClient(endpoint)
       ),
-    [token, handleNewToken, enqueueSnackbar, handleLogout, externalAuthLoginUrl]
+    [
+      token,
+      handleNewToken,
+      enqueueSnackbar,
+      handleSessionExpired,
+      externalAuthLoginUrl,
+    ]
   );
 }
 


### PR DESCRIPTION
Description
When a users session expires the user is currently redirected to the OIDC session logout endpoint, the user should instead be redirected to re-login. The user should only be redirected to the OIDC logout on explicit logout

Motivation and Context
Fixes confusing behaviour for users that has had session expiring